### PR TITLE
Use Google Drive for image storage

### DIFF
--- a/app/api/image/[fileid]/route.ts
+++ b/app/api/image/[fileid]/route.ts
@@ -1,40 +1,35 @@
 // app/api/image/[filename]/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import path from "path";
-import { readFile } from "fs/promises";
-import fs from "fs";
 import { deleteImage, getImageById } from "@/lib/store-utils";
+import { downloadStream, deleteFile as deleteDriveFile, updateFile as updateDriveFile } from "@/lib/drive_actions";
+import sharp from "sharp";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 // @ts-expect-error: the normal type i wuld have assigned to params arg was recognized as type error by nextjs
-export async function GET( _: NextRequest, { params }) {
-  //   const session = await getServerSession(authOptions);
-  //   if (!session) {
-  //     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  //   }
-
+export async function GET(_: NextRequest, { params }) {
   const { fileid } = await params;
-  console.log({ fileid });
-  const image = await getImageById(fileid); 
+  const image = await getImageById(fileid);
   if (!image) {
     return NextResponse.json({ error: "Image not found" }, { status: 404 });
   }
 
-  const filePath = path.join(process.cwd(), "uploads", image.src);
-
-  // Check if file exists
-  if (!fs.existsSync(filePath)) {
-    return NextResponse.json({ error: "File not found" }, { status: 404 });
+  try {
+    const stream = await downloadStream(image.src);
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    const fileBuffer = Buffer.concat(chunks);
+    return new NextResponse(fileBuffer, {
+      headers: {
+        "Content-Type": "image/jpeg",
+        "Content-Disposition": `inline; fileid="${fileid}"`,
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: "Failed to fetch file" }, { status: 500 });
   }
-
-  const fileBuffer = await readFile(filePath);
-  // Optionally, set the correct content type based on file extension
-  return new NextResponse(fileBuffer, {
-    headers: {
-      "Content-Type": "image/jpeg", // or detect dynamically
-      "Content-Disposition": `inline; fileid="${fileid}"`,
-    },
-  });
 }
 
 // @ts-expect-error: the normal type I would have assigned to params arg was recognized as type error by nextjs
@@ -44,16 +39,10 @@ export async function DELETE(_: NextRequest, { params }) {
   if (!image) {
     return NextResponse.json({ error: "Image not found" }, { status: 404 });
   }
-  const filePath = path.join(process.cwd(), "uploads", image.src);
-  if (!fs.existsSync(filePath)) {
-    return NextResponse.json({ error: "File not found" }, { status: 404 });
-  }
   try {
-    fs.unlinkSync(filePath);
+    await deleteDriveFile(image.src);
     return NextResponse.json({ success: true });
-  
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (err) {
+  } catch {
     return NextResponse.json({ error: "Failed to delete file" }, { status: 500 });
   }
 }
@@ -64,10 +53,6 @@ export async function PUT(request: NextRequest, { params }) {
   const image = await getImageById(fileid);
   if (!image) {
     return NextResponse.json({ error: "Image not found" }, { status: 404 });
-  } 
-  const filePath = path.join(process.cwd(), "uploads", image.src);
-  if (!fs.existsSync(filePath)) {
-    return NextResponse.json({ error: "File not found" }, { status: 404 });
   }
   const formData = await request.formData();
   const file = formData.get("file");
@@ -75,12 +60,26 @@ export async function PUT(request: NextRequest, { params }) {
     return NextResponse.json({ error: "No file uploaded" }, { status: 400 });
   }
   const arrayBuffer = await file.arrayBuffer();
-  const buffer = Buffer.from(arrayBuffer);
+  let buffer = Buffer.from(arrayBuffer);
+  const ext = path.extname(file.name).toLowerCase();
+  if (ext === ".jpg" || ext === ".jpeg") {
+    buffer = await sharp(buffer).resize({ width: 1200 }).jpeg({ quality: 80 }).toBuffer();
+  } else if (ext === ".png") {
+    buffer = await sharp(buffer).resize({ width: 1200 }).png({ quality: 80 }).toBuffer();
+  } else if (ext === ".webp") {
+    buffer = await sharp(buffer).resize({ width: 1200 }).webp({ quality: 80 }).toBuffer();
+  } else if (ext === ".heic") {
+    buffer = await sharp(buffer).resize({ width: 1200 }).jpeg({ quality: 80 }).toBuffer();
+  } else {
+    buffer = await sharp(buffer).resize({ width: 1200 }).jpeg({ quality: 80 }).toBuffer();
+  }
+  let mimeType = "image/jpeg";
+  if (ext === ".png") mimeType = "image/png";
+  else if (ext === ".webp") mimeType = "image/webp";
   try {
-    fs.writeFileSync(filePath, buffer);
+    await updateDriveFile(image.src, buffer, mimeType);
     return NextResponse.json({ success: true });
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (err) {
+  } catch {
     return NextResponse.json({ error: "Failed to update file" }, { status: 500 });
   }
 }

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -3,10 +3,10 @@ import path from "path";
 import { getImages } from "@/lib/store-utils";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
-import { mkdir, writeFile } from "fs/promises";
 import { addImage } from "@/lib/store-utils";
 import { v4 as uuidv4 } from 'uuid';
 import sharp from "sharp";
+import { uploadBuffer } from "@/lib/drive_actions";
 
 export async function GET() {
     const images = await getImages();
@@ -24,7 +24,6 @@ export async function POST(req: NextRequest) {
     if (!file || typeof file === 'string') return NextResponse.json({ error: 'No file uploaded' }, { status: 400 });
 
     const id = uuidv4();
-    const src = file.name;
     const alt = (formData.get('alt') as string) || file.name;
     const title = (formData.get('title') as string) || file.name;
     const description = (formData.get('description') as string) || file.name;
@@ -66,22 +65,20 @@ export async function POST(req: NextRequest) {
         .toBuffer();
     }
 
-    // Ensure uploads directory exists
-    const uploadDir = path.join(process.cwd(), 'uploads');
-    await mkdir(uploadDir, { recursive: true });
+    let mimeType = "image/jpeg";
+    if (ext === ".png") mimeType = "image/png";
+    else if (ext === ".webp") mimeType = "image/webp";
 
-    // Save file in uploads (not public)
-    const uploadPath = path.join(uploadDir, file.name);
-    await writeFile(uploadPath, compressedBuffer);
+    const driveId = await uploadBuffer(compressedBuffer, file.name, mimeType);
 
     await addImage({
       id,
-      src,
+      src: driveId,
       alt,
       title,
       description,
       medium,
-      year
+      year,
     });
-    return NextResponse.json({ success: true, filename: file.name });
+    return NextResponse.json({ success: true, fileId: driveId });
 }

--- a/lib/authorize_google.ts
+++ b/lib/authorize_google.ts
@@ -1,11 +1,10 @@
 
-const {google} = require('googleapis');
+import { google } from 'googleapis';
+import dotenv from 'dotenv';
+
 //read the .env.local file
-
 function authorize() {
-  const dotenv = require('dotenv');
   dotenv.config({ path: '.env.local' });
-
 
   const CLIENT_ID = process.env.CLIENT_ID;
   const CLIENT_SECRET = process.env.CLIENT_SECRET;

--- a/lib/drive_actions.ts
+++ b/lib/drive_actions.ts
@@ -1,11 +1,11 @@
 import fs from 'fs';
-import {google} from 'googleapis';
-import {authorize} from './authorize_google';
-
+import { Readable } from 'stream';
+import { google } from 'googleapis';
+import { authorize } from './authorize_google';
 
 export const uploadBasic = async (path: string, name: string) => {
   const auth = authorize(); // ← usa OAuth2
-  const service = google.drive({version: 'v3', auth});
+  const service = google.drive({ version: 'v3', auth });
 
   const requestBody = {
     name: name,
@@ -27,9 +27,52 @@ export const uploadBasic = async (path: string, name: string) => {
   } catch (err) {
     throw err;
   }
-}
+};
 
+export const uploadBuffer = async (
+  buffer: Buffer,
+  name: string,
+  mimeType: string,
+) => {
+  const auth = authorize();
+  const service = google.drive({ version: 'v3', auth });
+  const requestBody = { name, fields: 'id' };
+  const media = {
+    mimeType,
+    body: Readable.from(buffer),
+  };
+  try {
+    const file = await service.files.create({ requestBody, media });
+    return file.data.id as string;
+  } catch (err) {
+    throw err;
+  }
+};
 
+export const deleteFile = async (fileId: string) => {
+  const auth = authorize();
+  const service = google.drive({ version: 'v3', auth });
+  try {
+    await service.files.delete({ fileId });
+  } catch (err) {
+    throw err;
+  }
+};
+
+export const updateFile = async (
+  fileId: string,
+  buffer: Buffer,
+  mimeType: string,
+) => {
+  const auth = authorize();
+  const service = google.drive({ version: 'v3', auth });
+  const media = { mimeType, body: Readable.from(buffer) };
+  try {
+    await service.files.update({ fileId, media });
+  } catch (err) {
+    throw err;
+  }
+};
 
 export const downloadStream = async (fileId: string) => {
   const auth = authorize();
@@ -45,7 +88,7 @@ export const downloadStream = async (fileId: string) => {
       })
       .on('end', () => {
         // opzionale: log fine stream
-      });   
+      });
 
     return driveRes.data;
   } catch (err) {
@@ -53,3 +96,4 @@ export const downloadStream = async (fileId: string) => {
     throw err;
   }
 };
+


### PR DESCRIPTION
## Summary
- add Drive helpers to upload, update, delete and stream files
- store uploaded images on Google Drive instead of local filesystem
- serve, update and delete images via Drive API
- switch Google authorization helper to ES module imports

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892109b1f60832da535840dffe9d736