### PR TITLE
Add admin reel selection and show_reel support

### DIFF
--- a/app/api/media/route.ts
+++ b/app/api/media/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { getAllMedia } from "@/lib/store-utils";
+
+export async function GET() {
+  const media = await getAllMedia();
+  return NextResponse.json(media);
+}

--- a/app/api/reels/[fileid]/route.ts
+++ b/app/api/reels/[fileid]/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { setShowReel } from "@/lib/store-utils";
+
+// @ts-expect-error: Next.js params typing
+export async function PATCH(req: NextRequest, { params }) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { fileid } = params;
+  const body = await req.json();
+  if (typeof body.show_reel !== "boolean") {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  await setShowReel(fileid, body.show_reel);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/reels/route.ts
+++ b/app/api/reels/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { getReels } from "@/lib/store-utils";
+
+export async function GET() {
+  const reels = await getReels();
+  return NextResponse.json(reels);
+}

--- a/components/reels-content.tsx
+++ b/components/reels-content.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, useCallback } from "react"
 import Image from "next/image"
 import { ChevronUp, ChevronDown, Play, Pause, ChevronUp as ExpandIcon, ChevronDown as CollapseIcon } from "lucide-react"
+import { useSession } from "next-auth/react"
 
 interface ReelMedia {
   id: string
@@ -10,8 +11,8 @@ interface ReelMedia {
   alt: string
   title: string
   description: string
-  type: "image" | "video"
-  duration?: number // in seconds, for videos
+  medium: "image" | "video"
+  show_reel?: boolean
 }
 
 export function ReelsContent() {
@@ -22,50 +23,54 @@ export function ReelsContent() {
   const [videoLoading, setVideoLoading] = useState(false)
   const [isMounted, setIsMounted] = useState(false)
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
+  const [reelsMedia, setReelsMedia] = useState<ReelMedia[]>([])
+  const [allMedia, setAllMedia] = useState<ReelMedia[]>([])
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const videoRefs = useRef<{ [key: string]: HTMLVideoElement | null }>({})
+  const { data: session } = useSession()
 
-  // Sample media data - you can replace with your actual images/videos
-  const reelsMedia: ReelMedia[] = [
-    {
-      id: "artwork-1",
-      src: "/assets/IMG_4662.png",
-      alt: "Intersezioni Silenziose - Opera astratta con rete di linee incrociate, apparentemente casuali ma disposte con equilibrio e ritmo",
-      title: "Intersezioni Silenziose",
-      description: "Questa opera astratta gioca con una rete di linee incrociate, apparentemente casuali, ma disposte con equilibrio e ritmo. I tratti rossi, bianchi e bruni emergono su uno sfondo etereo dalle sfumature neutre, suggerendo un paesaggio mentale fatto di connessioni, separazioni e dialoghi silenziosi. Ogni incrocio può essere letto come un punto d'incontro tra pensieri, memorie o emozioni, lasciando spazio all'interpretazione soggettiva dell'osservatore. L'insieme trasmette un senso di calma contemplativa e struttura fluttuante.",
-      type: "image"
-    },
-    {
-      id: "reel-2",
-      src: "/assets/giovanna_video.MP4",
-      alt: "Artistic Creation 1",
-      title: "Realizzazione Intersezioni Silenziose",
-      description: "Questa opera astratta gioca con una rete di linee incrociate, apparentemente casuali, ma disposte con equilibrio e ritmo. I tratti rossi, bianchi e bruni emergono su uno sfondo etereo dalle sfumature neutre, suggerendo un paesaggio mentale fatto di connessioni, separazioni e dialoghi silenziosi. Ogni incrocio può essere letto come un punto d'incontro tra pensieri, memorie o emozioni, lasciando spazio all'interpretazione soggettiva dell'osservatore. L'insieme trasmette un senso di calma contemplativa e struttura fluttuante.",
-      type: "video"
-    },
-   
-  ]
-
-  const nextReel = () => {
-    setCurrentIndex((prev) => (prev + 1) % reelsMedia.length)
-    setIsDescriptionExpanded(false) // Reset expansion when changing reels
-  }
-
-  const previousReel = () => {
-    setCurrentIndex((prev) => (prev - 1 + reelsMedia.length) % reelsMedia.length)
-    setIsDescriptionExpanded(false) // Reset expansion when changing reels
-  }
-
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "ArrowDown" || e.key === " ") {
-      e.preventDefault()
-      nextReel()
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault()
-      previousReel()
+  const fetchReels = async () => {
+    try {
+      const res = await fetch('/api/reels')
+      const data = await res.json()
+      setReelsMedia(data)
+    } catch {
+      setReelsMedia([])
     }
   }
+
+  const fetchAllMedia = async () => {
+    try {
+      const res = await fetch('/api/media')
+      const data = await res.json()
+      setAllMedia(data)
+    } catch {
+      setAllMedia([])
+    }
+  }
+
+  const toggleShowReel = async (id: string, show: boolean) => {
+    await fetch(`/api/reels/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ show_reel: show })
+    })
+    setAllMedia(prev => prev.map(m => m.id === id ? { ...m, show_reel: show } : m))
+    fetchReels()
+  }
+
+  const nextReel = useCallback(() => {
+    if (reelsMedia.length === 0) return
+    setCurrentIndex((prev) => (prev + 1) % reelsMedia.length)
+    setIsDescriptionExpanded(false) // Reset expansion when changing reels
+  }, [reelsMedia.length])
+
+  const previousReel = useCallback(() => {
+    if (reelsMedia.length === 0) return
+    setCurrentIndex((prev) => (prev - 1 + reelsMedia.length) % reelsMedia.length)
+    setIsDescriptionExpanded(false) // Reset expansion when changing reels
+  }, [reelsMedia.length])
 
   const togglePlayPause = () => {
     setIsPlaying(!isPlaying)
@@ -84,24 +89,29 @@ export function ReelsContent() {
 
   useEffect(() => {
     setIsMounted(true)
+    fetchReels()
   }, [])
 
   useEffect(() => {
     if (!isMounted) return
-
-
-      window.addEventListener("keydown", handleKeyDown)
-
-
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "ArrowDown" || e.key === " ") {
+        e.preventDefault()
+        nextReel()
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault()
+        previousReel()
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown)
     return () => {
-
       window.removeEventListener("keydown", handleKeyDown)
     }
-  }, [isMounted, handleKeyDown])
+  }, [isMounted, nextReel, previousReel])
 
   useEffect(() => {
     // Auto-advance every 5 seconds if autoplay is enabled
-    if (isAutoPlay && isMounted) {
+    if (isAutoPlay && isMounted && reelsMedia.length > 0) {
       const interval = setInterval(() => {
         setCurrentIndex((prev) => (prev + 1) % reelsMedia.length)
         setIsDescriptionExpanded(false) // Reset expansion on auto-advance
@@ -109,14 +119,14 @@ export function ReelsContent() {
 
       return () => clearInterval(interval)
     }
-  }, [isAutoPlay, reelsMedia.length, isMounted, currentIndex, reelsMedia])
+  }, [isAutoPlay, reelsMedia.length, isMounted])
 
   useEffect(() => {
     // Handle video playback
-    if (!isMounted) return
+    if (!isMounted || reelsMedia.length === 0) return
 
     const currentVideo = videoRefs.current[reelsMedia[currentIndex].id]
-    if (currentVideo && reelsMedia[currentIndex].type === "video") {
+    if (currentVideo && reelsMedia[currentIndex].medium === "video") {
       if (isPlaying) {
         // Use a more robust approach to handle video playback
         const playPromise = currentVideo.play()
@@ -131,187 +141,224 @@ export function ReelsContent() {
         currentVideo.pause()
       }
     }
-    
+
     // Clear video error and loading state when changing media
     setVideoError(null)
     setVideoLoading(false)
-  }, [currentIndex, isPlaying, isMounted])
+  }, [currentIndex, isPlaying, isMounted, reelsMedia])
+
+  useEffect(() => {
+    setCurrentIndex(0)
+  }, [reelsMedia.length])
 
   const currentMedia = reelsMedia[currentIndex]
-  const isDescriptionLong = currentMedia.description.length > 150
+  const isDescriptionLong = currentMedia ? currentMedia.description.length > 150 : false
 
   // Don't render until mounted to prevent hydration mismatch
   if (!isMounted) {
     return (
       <div className="flex justify-center py-12">
-          <div className="text-gray-600">Caricamento reels...</div>
+        <div className="text-gray-600">Caricamento reels...</div>
       </div>
     )
   }
 
   return (
     <div className="space-y-8">
-      <p className="text-lg text-center max-w-2xl mx-auto text-gray-700">
-          Scorri attraverso il mio percorso artistico con questa esperienza visiva interattiva
-      </p>
-      
-      <div 
-        ref={containerRef}
-        className="relative h-[80vh] max-h-[600px] w-full max-w-md mx-auto bg-black rounded-2xl overflow-hidden shadow-2xl"
-      >
-        {/* Current Media Display */}
-        <div className="relative w-full h-full">
-          {currentMedia.type === "image" ? (
-            <Image
-              src={`/api/image/${currentMedia.id}?cb=${Date.now()}`}
-              alt={currentMedia.alt}
-              fill
-              className="object-cover"
-              priority
-            />
-          ) : (
-            <>
-              <video
-                ref={(el) => {
-                  videoRefs.current[currentMedia.id] = el
-                }}
-                src={`/api/video/${currentMedia.id}?cb=${Date.now()}`}
-                className="w-full h-full object-cover"
-                loop
-                muted
-                playsInline
-                controls={false}
-                preload="metadata"
-                onLoadStart={() => setVideoLoading(true)}
-                onLoadedData={() => {
-                  setVideoLoading(false)
-                  const video = videoRefs.current[currentMedia.id]
-                  if (video && isPlaying) {
-                    video.play().catch(console.log)
-                  }
-                }}
-                onError={(e) => {
-                  console.log("Video error:", e)
-                  setVideoLoading(false)
-                  setVideoError("Impossibile caricare il video. Per favore, prova a ricaricare la pagina.")
-                }}
-              >
-                <source src={`/api/video/${currentMedia.id}`} type="video/mp4" />
-                Il tuo browser non supporta il tag video.
-              </video>
-              
-              {/* Loading indicator */}
-              {videoLoading && (
-                <div className="absolute inset-0 flex items-center justify-center bg-black/50">
-                  <div className="text-white text-lg">Caricamento video...</div>
-                </div>
-              )}
-              
-              {/* Fallback for video errors */}
-              {videoError && (
-                <div className="absolute inset-0 flex items-center justify-center bg-gray-900">
-                  <div className="text-white text-center p-4">
-                    <div className="text-lg mb-2">Video non disponibile</div>
-                    <div className="text-sm opacity-75">{videoError}</div>
-                  </div>
-                </div>
-              )}
-            </>
-          )}
-
-          {/* Overlay with media info - now with expandable description */}
-          <div className={`absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-6 text-white transition-all duration-300 ${
-            isDescriptionExpanded ? 'h-full' : ''
-          }`}>
-            <div className={`transition-all duration-300 ${
-              isDescriptionExpanded ? 'h-full flex flex-col justify-end' : ''
-            }`}>
-              <h3 className="text-xl font-semibold mb-2">{currentMedia.title}</h3>
-              <div className="relative">
-                <p className={`text-sm opacity-90 transition-all duration-300 ${
-                  isDescriptionExpanded ? 'max-h-none' : 'max-h-16 overflow-hidden'
-                }`}>
-                  {isDescriptionExpanded ? currentMedia.description : truncateText(currentMedia.description)}
-                </p>
-                {isDescriptionLong && (
-                  <button
-                    onClick={toggleDescription}
-                    className="mt-2 flex items-center text-xs text-blue-300 hover:text-blue-200 transition-colors"
-                  >
-                    {isDescriptionExpanded ? (
-                      <>
-                        <CollapseIcon size={12} className="mr-1" />
-                        Mostra meno
-                      </>
-                    ) : (
-                      <>
-                        <ExpandIcon size={12} className="mr-1" />
-                        Leggi tutto
-                      </>
-                    )}
-                  </button>
-                )}
-              </div>
-              {videoError && currentMedia.type === "video" && (
-                <div className="mt-2 p-2 bg-yellow-500/80 rounded text-xs">
-                  {videoError}
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Navigation Controls */}
-          <div className="absolute top-4 right-4 flex flex-col space-y-2">
-            <button
-              onClick={togglePlayPause}
-              className="p-2 bg-black/50 rounded-full text-white hover:bg-black/70 transition-colors"
-            >
-              {isPlaying ? <Pause size={20} /> : <Play size={20} />}
-            </button>
-          </div>
-
-          {/* Progress Indicator */}
-          <div className="absolute top-4 left-4 right-4">
-            <div className="flex space-x-1">
-              {reelsMedia.map((_, index) => (
-                <div
-                  key={index}
-                  className={`h-1 flex-1 rounded-full transition-all duration-300 ${
-                    index === currentIndex
-                      ? "bg-white"
-                      : index < currentIndex
-                      ? "bg-white/50"
-                      : "bg-white/20"
-                  }`}
-                />
+      {session && (
+        <div className="text-center">
+          <button
+            onClick={async () => {
+              if (!isMenuOpen) await fetchAllMedia()
+              setIsMenuOpen(!isMenuOpen)
+            }}
+            className="px-4 py-2 mb-4 bg-gray-800 text-white rounded"
+          >
+            {isMenuOpen ? "Chiudi selezione" : "Seleziona reels"}
+          </button>
+          {isMenuOpen && (
+            <div className="max-h-60 overflow-y-auto border p-4 rounded bg-white text-gray-800 mx-auto mb-4 w-full max-w-md">
+              {allMedia.map((m) => (
+                <label key={m.id} className="flex items-center space-x-2 mb-2">
+                  <input
+                    type="checkbox"
+                    checked={m.show_reel ?? false}
+                    onChange={(e) => toggleShowReel(m.id, e.target.checked)}
+                  />
+                  <span>{m.title}</span>
+                </label>
               ))}
             </div>
-          </div>
-
-          {/* Navigation Arrows */}
-          <button
-            onClick={previousReel}
-            className="absolute left-4 top-1/2 transform -translate-y-1/2 p-2 bg-black/50 rounded-full text-white hover:bg-black/70 transition-colors"
-          >
-            <ChevronUp size={24} />
-          </button>
-          <button
-            onClick={nextReel}
-            className="absolute right-4 top-1/2 transform -translate-y-1/2 p-2 bg-black/50 rounded-full text-white hover:bg-black/70 transition-colors"
-          >
-            <ChevronDown size={24} />
-          </button>
+          )}
         </div>
-      </div>
+      )}
 
-      {/* Instructions */}
-      <div className="text-center text-sm text-gray-600 space-y-2">
-        <p>Usa le frecce o clicca sui pulsanti per navigare</p>
-        <p>Clicca sul pulsante play/pause per controllare l&apos;autoplay</p>
-        <p className="text-xs">
-          {currentIndex + 1} of {reelsMedia.length}
-        </p>
-      </div>
+      <p className="text-lg text-center max-w-2xl mx-auto text-gray-700">
+        Scorri attraverso il mio percorso artistico con questa esperienza visiva interattiva
+      </p>
+
+      {reelsMedia.length > 0 ? (
+        <div
+          ref={containerRef}
+          className="relative h-[80vh] max-h-[600px] w-full max-w-md mx-auto bg-black rounded-2xl overflow-hidden shadow-2xl"
+        >
+          {/* Current Media Display */}
+          <div className="relative w-full h-full">
+            {currentMedia.medium === "image" ? (
+              <Image
+                src={`/api/image/${currentMedia.id}?cb=${Date.now()}`}
+                alt={currentMedia.alt}
+                fill
+                className="object-cover"
+                priority
+              />
+            ) : (
+              <>
+                <video
+                  ref={(el) => {
+                    videoRefs.current[currentMedia.id] = el
+                  }}
+                  src={`/api/video/${currentMedia.id}?cb=${Date.now()}`}
+                  className="w-full h-full object-cover"
+                  loop
+                  muted
+                  playsInline
+                  controls={false}
+                  preload="metadata"
+                  onLoadStart={() => setVideoLoading(true)}
+                  onLoadedData={() => {
+                    setVideoLoading(false)
+                    const video = videoRefs.current[currentMedia.id]
+                    if (video && isPlaying) {
+                      video.play().catch(console.log)
+                    }
+                  }}
+                  onError={(e) => {
+                    console.log("Video error:", e)
+                    setVideoLoading(false)
+                    setVideoError("Impossibile caricare il video. Per favore, prova a ricaricare la pagina.")
+                  }}
+                >
+                  <source src={`/api/video/${currentMedia.id}`} type="video/mp4" />
+                  Il tuo browser non supporta il tag video.
+                </video>
+
+                {/* Loading indicator */}
+                {videoLoading && (
+                  <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+                    <div className="text-white text-lg">Caricamento video...</div>
+                  </div>
+                )}
+
+                {/* Fallback for video errors */}
+                {videoError && (
+                  <div className="absolute inset-0 flex items-center justify-center bg-gray-900">
+                    <div className="text-white text-center p-4">
+                      <div className="text-lg mb-2">Video non disponibile</div>
+                      <div className="text-sm opacity-75">{videoError}</div>
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+
+            {/* Overlay with media info - now with expandable description */}
+            <div className={`absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-6 text-white transition-all duration-300 ${
+              isDescriptionExpanded ? 'h-full' : ''
+            }`}>
+              <div className={`transition-all duration-300 ${
+                isDescriptionExpanded ? 'h-full flex flex-col justify-end' : ''
+              }`}>
+                <h3 className="text-xl font-semibold mb-2">{currentMedia.title}</h3>
+                <div className="relative">
+                  <p className={`text-sm opacity-90 transition-all duration-300 ${
+                    isDescriptionExpanded ? 'max-h-none' : 'max-h-16 overflow-hidden'
+                  }`}>
+                    {isDescriptionExpanded ? currentMedia.description : truncateText(currentMedia.description)}
+                  </p>
+                  {isDescriptionLong && (
+                    <button
+                      onClick={toggleDescription}
+                      className="mt-2 flex items-center text-xs text-blue-300 hover:text-blue-200 transition-colors"
+                    >
+                      {isDescriptionExpanded ? (
+                        <>
+                          <CollapseIcon size={12} className="mr-1" />
+                          Mostra meno
+                        </>
+                      ) : (
+                        <>
+                          <ExpandIcon size={12} className="mr-1" />
+                          Leggi tutto
+                        </>
+                      )}
+                    </button>
+                  )}
+                </div>
+                {videoError && currentMedia.medium === "video" && (
+                  <div className="mt-2 p-2 bg-yellow-500/80 rounded text-xs">
+                    {videoError}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Navigation Controls */}
+            <div className="absolute top-4 right-4 flex flex-col space-y-2">
+              <button
+                onClick={togglePlayPause}
+                className="p-2 bg-black/50 rounded-full text-white hover:bg-black/70 transition-colors"
+              >
+                {isPlaying ? <Pause size={20} /> : <Play size={20} />}
+              </button>
+            </div>
+
+            {/* Progress Indicator */}
+            <div className="absolute top-4 left-4 right-4">
+              <div className="flex space-x-1">
+                {reelsMedia.map((_, index) => (
+                  <div
+                    key={index}
+                    className={`h-1 flex-1 rounded-full transition-all duration-300 ${
+                      index === currentIndex
+                        ? "bg-white"
+                        : index < currentIndex
+                        ? "bg-white/50"
+                        : "bg-white/20"
+                    }`}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Navigation Arrows */}
+            <button
+              onClick={previousReel}
+              className="absolute left-4 top-1/2 transform -translate-y-1/2 p-2 bg-black/50 rounded-full text-white hover:bg-black/70 transition-colors"
+            >
+              <ChevronUp size={24} />
+            </button>
+            <button
+              onClick={nextReel}
+              className="absolute right-4 top-1/2 transform -translate-y-1/2 p-2 bg-black/50 rounded-full text-white hover:bg-black/70 transition-colors"
+            >
+              <ChevronDown size={24} />
+            </button>
+          </div>
+        </div>
+      ) : (
+        <p className="text-center text-gray-600">Nessun reel selezionato.</p>
+      )}
+
+      {reelsMedia.length > 0 && (
+        <div className="text-center text-sm text-gray-600 space-y-2">
+          <p>Usa le frecce o clicca sui pulsanti per navigare</p>
+          <p>Clicca sul pulsante play/pause per controllare l&apos;autoplay</p>
+          <p className="text-xs">
+            {currentIndex + 1} of {reelsMedia.length}
+          </p>
+        </div>
+      )}
     </div>
   )
-} 
+}

--- a/lib/authorize_google.ts
+++ b/lib/authorize_google.ts
@@ -1,29 +1,27 @@
+import { google } from 'googleapis'
+import dotenv from 'dotenv'
 
-const {google} = require('googleapis');
 //read the .env.local file
-
 function authorize() {
-  const dotenv = require('dotenv');
-  dotenv.config({ path: '.env.local' });
+  dotenv.config({ path: '.env.local' })
 
-
-  const CLIENT_ID = process.env.CLIENT_ID;
-  const CLIENT_SECRET = process.env.CLIENT_SECRET;
-  const REDIRECT_URI = process.env.REDIRECT_URI;
-  const ACCESS_TOKEN = process.env.ACCESS_TOKEN;
-  const REFRESH_TOKEN = process.env.REFRESH_TOKEN;
+  const CLIENT_ID = process.env.CLIENT_ID
+  const CLIENT_SECRET = process.env.CLIENT_SECRET
+  const REDIRECT_URI = process.env.REDIRECT_URI
+  const ACCESS_TOKEN = process.env.ACCESS_TOKEN
+  const REFRESH_TOKEN = process.env.REFRESH_TOKEN
 
   const oAuth2Client = new google.auth.OAuth2(
     CLIENT_ID,
     CLIENT_SECRET,
     REDIRECT_URI
-  );
+  )
   oAuth2Client.setCredentials({
     access_token: ACCESS_TOKEN,
     refresh_token: REFRESH_TOKEN,
-  });
+  })
 
-  return oAuth2Client;
+  return oAuth2Client
 }
 
-export { authorize };
+export { authorize }

--- a/lib/store-utils.ts
+++ b/lib/store-utils.ts
@@ -8,6 +8,7 @@ export type ImageRecord = {
   description: string;
   medium: string;
   year: string;
+  show_reel?: boolean;
 };
 
 const collectionName = "images";
@@ -25,6 +26,7 @@ export const getImageById = async (id: string): Promise<ImageRecord | undefined>
 
 export const addImage = async (image: ImageRecord): Promise<void> => {
   image.medium = "image";
+  image.show_reel = false;
   const collection = await getCollection<ImageRecord>(collectionName);
   await collection.insertOne(image);
 };
@@ -54,4 +56,19 @@ export const getVideoById = async (id: string): Promise<ImageRecord | undefined>
   const collection = await getCollection<ImageRecord>(collectionName);
   const video = await collection.findOne({ id, medium: "video" });
   return video ?? undefined;
+};
+
+export const getAllMedia = async (): Promise<ImageRecord[]> => {
+  const collection = await getCollection<ImageRecord>(collectionName);
+  return collection.find({}).toArray();
+};
+
+export const getReels = async (): Promise<ImageRecord[]> => {
+  const collection = await getCollection<ImageRecord>(collectionName);
+  return collection.find({ show_reel: true }).toArray();
+};
+
+export const setShowReel = async (id: string, show: boolean): Promise<void> => {
+  const collection = await getCollection<ImageRecord>(collectionName);
+  await collection.updateOne({ id }, { $set: { show_reel: show } });
 };


### PR DESCRIPTION
## Summary
- add `show_reel` flag and helpers for managing reel visibility
- expose API endpoints to list media and toggle `show_reel`
- allow admins to pick reel items through ReelsContent
- convert Google auth helper to ES module syntax

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689217581484832d930330ad6eacb73a