### PR TITLE
feat: allow selecting media for reels

### DIFF
--- a/app/api/image/[fileid]/route.ts
+++ b/app/api/image/[fileid]/route.ts
@@ -5,7 +5,6 @@ import { deleteImage, getImageById } from "@/lib/store-utils";
 import { downloadStream, deleteFile as deleteDriveFile, updateFile as updateDriveFile } from "@/lib/drive_actions";
 import sharp from "sharp";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 // @ts-expect-error: the normal type i wuld have assigned to params arg was recognized as type error by nextjs
 export async function GET(_: NextRequest, { params }) {
   const { fileid } = await params;

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -4,14 +4,14 @@ import { getImages } from "@/lib/store-utils";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { addImage } from "@/lib/store-utils";
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4 } from "uuid";
 import sharp from "sharp";
 import { uploadBuffer } from "@/lib/drive_actions";
 
-export async function GET() {
-    const images = await getImages();
-
-    return NextResponse.json(images);
+export async function GET(req: NextRequest) {
+  const includeAll = req.nextUrl.searchParams.get("all") === "1";
+  const images = await getImages(includeAll);
+  return NextResponse.json(images);
 }
 
 export async function POST(req: NextRequest) {
@@ -29,6 +29,8 @@ export async function POST(req: NextRequest) {
     const description = (formData.get('description') as string) || file.name;
     const medium = (formData.get('medium') as string) || file.name;
     const year = (formData.get('year') as string) || file.name;
+    const showReel = formData.get('show_reel') === 'true';
+    const reelOnly = formData.get('reel_only') === 'true';
 
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);
@@ -79,6 +81,8 @@ export async function POST(req: NextRequest) {
       description,
       medium,
       year,
+      show_reel: showReel,
+      reel_only: reelOnly,
     });
     return NextResponse.json({ success: true, fileId: driveId });
 }

--- a/app/api/reel/[fileid]/route.ts
+++ b/app/api/reel/[fileid]/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { setShowReel } from "@/lib/store-utils";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+// @ts-expect-error params type is provided by Next.js runtime
+export async function PUT(req: NextRequest, { params }) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { fileid } = params;
+  const body = await req.json();
+  await setShowReel(fileid, !!body.show_reel);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/reel/route.ts
+++ b/app/api/reel/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { getReelMedia } from "@/lib/store-utils";
+
+export async function GET() {
+  const media = await getReelMedia();
+  return NextResponse.json(media);
+}

--- a/app/api/video/[fileid]/route.ts
+++ b/app/api/video/[fileid]/route.ts
@@ -4,7 +4,6 @@ import path from "path";
 import fs from "fs";
 import { getVideoById } from "@/lib/store-utils";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 // @ts-expect-error: the normal type I would have assigned to params arg was recognized as type error by nextjs
 export async function GET(request: NextRequest, { params }) {
   const { fileid } = params;
@@ -82,7 +81,6 @@ export async function GET(request: NextRequest, { params }) {
 //     fs.unlinkSync(filePath);
 //     return NextResponse.json({ success: true });
   
-//     // eslint-disable-next-line @typescript-eslint/no-unused-vars
 //   } catch (err) {
 //     return NextResponse.json({ error: "Failed to delete file" }, { status: 500 });
 //   }
@@ -109,7 +107,6 @@ export async function GET(request: NextRequest, { params }) {
 //   try {
 //     fs.writeFileSync(filePath, buffer);
 //     return NextResponse.json({ success: true });
-//     // eslint-disable-next-line @typescript-eslint/no-unused-vars
 //   } catch (err) {
 //     return NextResponse.json({ error: "Failed to update file" }, { status: 500 });
 //   }

--- a/app/api/video/route.ts
+++ b/app/api/video/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import path from "path";
+import fs from "fs";
+import { getVideos, addVideo } from "@/lib/store-utils";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { v4 as uuidv4 } from "uuid";
+
+export async function GET(req: NextRequest) {
+  const includeAll = req.nextUrl.searchParams.get("all") === "1";
+  const videos = await getVideos(includeAll);
+  return NextResponse.json(videos);
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const formData = await req.formData();
+  const file = formData.get("file");
+  if (!file || typeof file === "string") {
+    return NextResponse.json({ error: "No file uploaded" }, { status: 400 });
+  }
+
+  const id = uuidv4();
+  const alt = (formData.get("alt") as string) || file.name;
+  const title = (formData.get("title") as string) || file.name;
+  const description = (formData.get("description") as string) || file.name;
+  const year = (formData.get("year") as string) || new Date().getFullYear().toString();
+  const showReel = formData.get("show_reel") === "true";
+  const reelOnly = formData.get("reel_only") === "true";
+
+  const bytes = await file.arrayBuffer();
+  const buffer = Buffer.from(bytes);
+  const filename = `${id}${path.extname(file.name)}`;
+  const uploadPath = path.join(process.cwd(), "uploads", filename);
+  await fs.promises.writeFile(uploadPath, buffer);
+
+  await addVideo({
+    id,
+    src: filename,
+    alt,
+    title,
+    description,
+    medium: "video",
+    year,
+    show_reel: showReel,
+    reel_only: reelOnly,
+  });
+
+  return NextResponse.json({ success: true, fileId: filename });
+}

--- a/components/reels-content.tsx
+++ b/components/reels-content.tsx
@@ -1,8 +1,10 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, useCallback } from "react"
 import Image from "next/image"
 import { ChevronUp, ChevronDown, Play, Pause, ChevronUp as ExpandIcon, ChevronDown as CollapseIcon } from "lucide-react"
+import { useSession } from "next-auth/react"
+import { Button } from "@/components/ui/button"
 
 interface ReelMedia {
   id: string
@@ -10,7 +12,8 @@ interface ReelMedia {
   alt: string
   title: string
   description: string
-  type: "image" | "video"
+  medium: "image" | "video"
+  show_reel?: boolean
   duration?: number // in seconds, for videos
 }
 
@@ -24,48 +27,38 @@ export function ReelsContent() {
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const videoRefs = useRef<{ [key: string]: HTMLVideoElement | null }>({})
+  const { data: session } = useSession()
+  const [reelsMedia, setReelsMedia] = useState<ReelMedia[]>([])
+  const [allMedia, setAllMedia] = useState<ReelMedia[]>([])
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [uploadFile, setUploadFile] = useState<File | null>(null)
 
-  // Sample media data - you can replace with your actual images/videos
-  const reelsMedia: ReelMedia[] = [
-    {
-      id: "artwork-1",
-      src: "/assets/IMG_4662.png",
-      alt: "Intersezioni Silenziose - Opera astratta con rete di linee incrociate, apparentemente casuali ma disposte con equilibrio e ritmo",
-      title: "Intersezioni Silenziose",
-      description: "Questa opera astratta gioca con una rete di linee incrociate, apparentemente casuali, ma disposte con equilibrio e ritmo. I tratti rossi, bianchi e bruni emergono su uno sfondo etereo dalle sfumature neutre, suggerendo un paesaggio mentale fatto di connessioni, separazioni e dialoghi silenziosi. Ogni incrocio può essere letto come un punto d'incontro tra pensieri, memorie o emozioni, lasciando spazio all'interpretazione soggettiva dell'osservatore. L'insieme trasmette un senso di calma contemplativa e struttura fluttuante.",
-      type: "image"
-    },
-    {
-      id: "reel-2",
-      src: "/assets/giovanna_video.MP4",
-      alt: "Artistic Creation 1",
-      title: "Realizzazione Intersezioni Silenziose",
-      description: "Questa opera astratta gioca con una rete di linee incrociate, apparentemente casuali, ma disposte con equilibrio e ritmo. I tratti rossi, bianchi e bruni emergono su uno sfondo etereo dalle sfumature neutre, suggerendo un paesaggio mentale fatto di connessioni, separazioni e dialoghi silenziosi. Ogni incrocio può essere letto come un punto d'incontro tra pensieri, memorie o emozioni, lasciando spazio all'interpretazione soggettiva dell'osservatore. L'insieme trasmette un senso di calma contemplativa e struttura fluttuante.",
-      type: "video"
-    },
-   
-  ]
+  const fetchReels = async () => {
+    const res = await fetch("/api/reel")
+    const data = await res.json()
+    setReelsMedia(data)
+  }
 
-  const nextReel = () => {
+  const fetchAllMedia = async () => {
+    const [imgsRes, vidsRes] = await Promise.all([
+      fetch("/api/image?all=1"),
+      fetch("/api/video?all=1"),
+    ])
+    const [imgs, vids] = await Promise.all([imgsRes.json(), vidsRes.json()])
+    setAllMedia([...imgs, ...vids])
+  }
+
+  const nextReel = useCallback(() => {
+    if (reelsMedia.length === 0) return
     setCurrentIndex((prev) => (prev + 1) % reelsMedia.length)
-    setIsDescriptionExpanded(false) // Reset expansion when changing reels
-  }
+    setIsDescriptionExpanded(false)
+  }, [reelsMedia.length])
 
-  const previousReel = () => {
+  const previousReel = useCallback(() => {
+    if (reelsMedia.length === 0) return
     setCurrentIndex((prev) => (prev - 1 + reelsMedia.length) % reelsMedia.length)
-    setIsDescriptionExpanded(false) // Reset expansion when changing reels
-  }
-
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "ArrowDown" || e.key === " ") {
-      e.preventDefault()
-      nextReel()
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault()
-      previousReel()
-    }
-  }
+    setIsDescriptionExpanded(false)
+  }, [reelsMedia.length])
 
   const togglePlayPause = () => {
     setIsPlaying(!isPlaying)
@@ -84,20 +77,43 @@ export function ReelsContent() {
 
   useEffect(() => {
     setIsMounted(true)
+    fetchReels()
   }, [])
+
+  useEffect(() => {
+    if (reelsMedia.length === 0) return
+    // Preload all media to avoid delays when navigating
+    reelsMedia.forEach((m) => {
+      if (m.medium === "image") {
+        const img = new window.Image()
+        img.src = `/api/image/${m.id}`
+      } else {
+        const video = document.createElement("video")
+        video.src = `/api/video/${m.id}`
+        video.preload = "auto"
+      }
+    })
+  }, [reelsMedia])
 
   useEffect(() => {
     if (!isMounted) return
 
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "ArrowDown" || e.key === " ") {
+        e.preventDefault()
+        nextReel()
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault()
+        previousReel()
+      }
+    }
 
-      window.addEventListener("keydown", handleKeyDown)
-
+    window.addEventListener("keydown", handleKeyDown)
 
     return () => {
-
       window.removeEventListener("keydown", handleKeyDown)
     }
-  }, [isMounted, handleKeyDown])
+  }, [isMounted, nextReel, previousReel])
 
   useEffect(() => {
     // Auto-advance every 5 seconds if autoplay is enabled
@@ -113,10 +129,10 @@ export function ReelsContent() {
 
   useEffect(() => {
     // Handle video playback
-    if (!isMounted) return
+    if (!isMounted || reelsMedia.length === 0) return
 
     const currentVideo = videoRefs.current[reelsMedia[currentIndex].id]
-    if (currentVideo && reelsMedia[currentIndex].type === "video") {
+    if (currentVideo && reelsMedia[currentIndex].medium === "video") {
       if (isPlaying) {
         // Use a more robust approach to handle video playback
         const playPromise = currentVideo.play()
@@ -135,10 +151,10 @@ export function ReelsContent() {
     // Clear video error and loading state when changing media
     setVideoError(null)
     setVideoLoading(false)
-  }, [currentIndex, isPlaying, isMounted])
+  }, [currentIndex, isPlaying, isMounted, reelsMedia])
 
   const currentMedia = reelsMedia[currentIndex]
-  const isDescriptionLong = currentMedia.description.length > 150
+  const isDescriptionLong = currentMedia ? currentMedia.description.length > 150 : false
 
   // Don't render until mounted to prevent hydration mismatch
   if (!isMounted) {
@@ -149,8 +165,31 @@ export function ReelsContent() {
     )
   }
 
+  if (!currentMedia) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="text-gray-600">Nessun media disponibile.</div>
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-8">
+      {session && (
+        <div className="text-right">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              const open = !menuOpen
+              setMenuOpen(open)
+              if (open) fetchAllMedia()
+            }}
+          >
+            Gestisci reels
+          </Button>
+        </div>
+      )}
       <p className="text-lg text-center max-w-2xl mx-auto text-gray-700">
           Scorri attraverso il mio percorso artistico con questa esperienza visiva interattiva
       </p>
@@ -161,9 +200,9 @@ export function ReelsContent() {
       >
         {/* Current Media Display */}
         <div className="relative w-full h-full">
-          {currentMedia.type === "image" ? (
+          {currentMedia.medium === "image" ? (
             <Image
-              src={`/api/image/${currentMedia.id}?cb=${Date.now()}`}
+              src={`/api/image/${currentMedia.id}`}
               alt={currentMedia.alt}
               fill
               className="object-cover"
@@ -175,7 +214,7 @@ export function ReelsContent() {
                 ref={(el) => {
                   videoRefs.current[currentMedia.id] = el
                 }}
-                src={`/api/video/${currentMedia.id}?cb=${Date.now()}`}
+                src={`/api/video/${currentMedia.id}`}
                 className="w-full h-full object-cover"
                 loop
                 muted
@@ -199,14 +238,14 @@ export function ReelsContent() {
                 <source src={`/api/video/${currentMedia.id}`} type="video/mp4" />
                 Il tuo browser non supporta il tag video.
               </video>
-              
+
               {/* Loading indicator */}
               {videoLoading && (
                 <div className="absolute inset-0 flex items-center justify-center bg-black/50">
                   <div className="text-white text-lg">Caricamento video...</div>
                 </div>
               )}
-              
+
               {/* Fallback for video errors */}
               {videoError && (
                 <div className="absolute inset-0 flex items-center justify-center bg-gray-900">
@@ -252,7 +291,7 @@ export function ReelsContent() {
                   </button>
                 )}
               </div>
-              {videoError && currentMedia.type === "video" && (
+              {videoError && currentMedia.medium === "video" && (
                 <div className="mt-2 p-2 bg-yellow-500/80 rounded text-xs">
                   {videoError}
                 </div>
@@ -312,6 +351,90 @@ export function ReelsContent() {
           {currentIndex + 1} of {reelsMedia.length}
         </p>
       </div>
+      {menuOpen && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white p-4 rounded max-h-[80vh] overflow-y-auto">
+            <h2 className="text-lg mb-4">Seleziona media da mostrare</h2>
+            <form
+              onSubmit={async (e) => {
+                e.preventDefault()
+                if (!uploadFile) return
+                const form = new FormData()
+                form.append("file", uploadFile)
+                form.append("title", uploadFile.name)
+                form.append("description", uploadFile.name)
+                form.append("year", new Date().getFullYear().toString())
+                form.append("show_reel", "true")
+                form.append("reel_only", "true")
+                const isVideo = uploadFile.type.startsWith("video")
+                await fetch(isVideo ? "/api/video" : "/api/image", {
+                  method: "POST",
+                  body: form,
+                })
+                setUploadFile(null)
+                await fetchReels()
+                await fetchAllMedia()
+              }}
+              className="mb-4 space-y-2"
+            >
+              <input
+                type="file"
+                accept="image/*,video/*"
+                onChange={(e) => setUploadFile(e.target.files?.[0] ?? null)}
+              />
+              <Button type="submit" size="sm" disabled={!uploadFile}>
+                Carica nuovo media
+              </Button>
+            </form>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              {allMedia.map((m) => (
+                <label key={m.id} className="flex flex-col items-center">
+                  {m.medium === "image" ? (
+                    <Image
+                      src={`/api/image/${m.id}`}
+                      alt={m.alt}
+                      width={100}
+                      height={100}
+                      className="object-cover"
+                    />
+                  ) : (
+                    <video
+                      src={`/api/video/${m.id}`}
+                      className="w-[100px] h-[100px] object-cover"
+                      muted
+                      loop
+                      playsInline
+                    />
+                  )}
+                  <input
+                    type="checkbox"
+                    className="mt-2"
+                    checked={m.show_reel === true}
+                    onChange={async (e) => {
+                      await fetch(`/api/reel/${m.id}`, {
+                        method: "PUT",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ show_reel: e.target.checked }),
+                      })
+                      await fetchReels()
+                      setAllMedia((prev) =>
+                        prev.map((item) =>
+                          item.id === m.id ? { ...item, show_reel: e.target.checked } : item
+                        )
+                      )
+                    }}
+                  />
+                </label>
+              ))}
+            </div>
+            <div className="mt-4 text-right">
+              <Button size="sm" onClick={() => setMenuOpen(false)}>
+                Chiudi
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
-} 
+}

--- a/lib/store-utils.ts
+++ b/lib/store-utils.ts
@@ -8,13 +8,18 @@ export type ImageRecord = {
   description: string;
   medium: string;
   year: string;
+  show_reel?: boolean;
+  reel_only?: boolean;
 };
 
 const collectionName = "images";
 
-export const getImages = async (): Promise<ImageRecord[]> => {
+export const getImages = async (includeReelOnly = false): Promise<ImageRecord[]> => {
   const collection = await getCollection<ImageRecord>(collectionName);
-  return collection.find({ medium: "image" }).toArray();
+  const filter = includeReelOnly
+    ? { medium: "image" }
+    : { medium: "image", $or: [{ reel_only: { $ne: true } }, { reel_only: { $exists: false } }] };
+  return collection.find(filter).toArray();
 };
 
 export const getImageById = async (id: string): Promise<ImageRecord | undefined> => {
@@ -45,13 +50,32 @@ export const deleteImage = async (id: string): Promise<ImageRecord | null> => {
   return result ?? null;
 };
 
-export const getVideos = async (): Promise<ImageRecord[]> => {
+export const getVideos = async (includeReelOnly = false): Promise<ImageRecord[]> => {
   const collection = await getCollection<ImageRecord>(collectionName);
-  return collection.find({ medium: "video" }).toArray();
+  const filter = includeReelOnly
+    ? { medium: "video" }
+    : { medium: "video", $or: [{ reel_only: { $ne: true } }, { reel_only: { $exists: false } }] };
+  return collection.find(filter).toArray();
 };
 
 export const getVideoById = async (id: string): Promise<ImageRecord | undefined> => {
   const collection = await getCollection<ImageRecord>(collectionName);
   const video = await collection.findOne({ id, medium: "video" });
   return video ?? undefined;
+};
+
+export const setShowReel = async (id: string, show: boolean): Promise<void> => {
+  const collection = await getCollection<ImageRecord>(collectionName);
+  await collection.updateOne({ id }, { $set: { show_reel: show } });
+};
+
+export const getReelMedia = async (): Promise<ImageRecord[]> => {
+  const collection = await getCollection<ImageRecord>(collectionName);
+  return collection.find({ show_reel: true }).toArray();
+};
+
+export const addVideo = async (video: ImageRecord): Promise<void> => {
+  video.medium = "video";
+  const collection = await getCollection<ImageRecord>(collectionName);
+  await collection.insertOne(video);
 };


### PR DESCRIPTION
## Summary
- add `reel_only` flag and helpers for media records
- expose API endpoints to fetch/update reel media
- load reels from database and provide admin-only selection UI
- allow uploading reel-only media and preload all reels for smoother navigation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68921abdd154832d9e7694ebd4e01680