### PR TITLE
feat: enable gallery tag editing

### DIFF
--- a/app/api/image/[fileid]/route.ts
+++ b/app/api/image/[fileid]/route.ts
@@ -1,7 +1,9 @@
 // app/api/image/[filename]/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import path from "path";
-import { deleteImage, getImageById } from "@/lib/store-utils";
+import { deleteImage, getImageById, updateImage } from "@/lib/store-utils";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
 import { downloadStream, deleteFile as deleteDriveFile, updateFile as updateDriveFile } from "@/lib/drive_actions";
 import sharp from "sharp";
 
@@ -81,4 +83,27 @@ export async function PUT(request: NextRequest, { params }) {
   } catch {
     return NextResponse.json({ error: "Failed to update file" }, { status: 500 });
   }
+}
+
+// @ts-expect-error: the normal type I would have assigned to params arg was recognized as type error by nextjs
+export async function PATCH(req: NextRequest, { params }) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { fileid } = await params;
+  const existing = await getImageById(fileid);
+  if (!existing) {
+    return NextResponse.json({ error: "Image not found" }, { status: 404 });
+  }
+  const body = await req.json();
+  const updated = {
+    ...existing,
+    show_reel:
+      typeof body.show_reel === "boolean" ? body.show_reel : existing.show_reel,
+    reel_only:
+      typeof body.reel_only === "boolean" ? body.reel_only : existing.reel_only,
+  };
+  await updateImage(updated);
+  return NextResponse.json({ success: true });
 }

--- a/components/gallery-content.tsx
+++ b/components/gallery-content.tsx
@@ -116,11 +116,28 @@ export function GalleryContent() {
       const res = await fetch("/api/image");
       const data = await res.json();
       setImages(data);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (_) {
       setImages([]);
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function updateTags(id: string, gallery: boolean, reels: boolean) {
+    try {
+      await fetch(`/api/image/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          show_reel: reels,
+          reel_only: reels && !gallery,
+        }),
+      });
+      fetchImages();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (_) {
+      /* ignore errors */
     }
   }
 
@@ -195,40 +212,64 @@ export function GalleryContent() {
                   Scopri di più
                 </Button>
                 {session && (
-                  <div className="flex gap-2 mt-2">
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={async () => {
-                        if (confirm("Sei sicuro di voler eliminare questa immagine?")) {
-                          const res = await fetch(`/api/image/${image.id}`, { method: "DELETE" });
-                          if (res.ok) fetchImages();
-                        }
-                      }}
-                    >
-                      Elimina
-                    </Button>
-                    <label className="inline-block">
-                      <input
-                        type="file"
-                        accept="image/*"
-                        style={{ display: "none" }}
-                        onChange={async (e) => {
-                          const file = e.target.files?.[0];
-                          if (!file) return;
-                          const formData = new FormData();
-                          formData.append("file", file);
-                          const res = await fetch(`/api/image/${image.id}`, {
-                            method: "PUT",
-                            body: formData,
-                          });
-                          if (res.ok) fetchImages();
+                  <div className="flex flex-col gap-2 mt-2">
+                    <div className="flex gap-4">
+                      <label className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={!image.reel_only}
+                          onChange={(e) =>
+                            updateTags(image.id, e.target.checked, image.show_reel === true)
+                          }
+                        />
+                        Gallery
+                      </label>
+                      <label className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={image.show_reel === true}
+                          onChange={(e) =>
+                            updateTags(image.id, !image.reel_only, e.target.checked)
+                          }
+                        />
+                        Reels
+                      </label>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={async () => {
+                          if (confirm("Sei sicuro di voler eliminare questa immagine?")) {
+                            const res = await fetch(`/api/image/${image.id}`, { method: "DELETE" });
+                            if (res.ok) fetchImages();
+                          }
                         }}
-                      />
-                      <Button asChild variant="secondary" size="sm">
-                        <span>Modifica</span>
+                      >
+                        Elimina
                       </Button>
-                    </label>
+                      <label className="inline-block">
+                        <input
+                          type="file"
+                          accept="image/*"
+                          style={{ display: "none" }}
+                          onChange={async (e) => {
+                            const file = e.target.files?.[0];
+                            if (!file) return;
+                            const formData = new FormData();
+                            formData.append("file", file);
+                            const res = await fetch(`/api/image/${image.id}`, {
+                              method: "PUT",
+                              body: formData,
+                            });
+                            if (res.ok) fetchImages();
+                          }}
+                        />
+                        <Button asChild variant="secondary" size="sm">
+                          <span>Modifica</span>
+                        </Button>
+                      </label>
+                    </div>
                   </div>
                 )}
               </CardContent>

--- a/lib/gallery.ts
+++ b/lib/gallery.ts
@@ -11,6 +11,8 @@ export interface GalleryImage {
   year: string
   data?: string // base64 image data
   contentType?: string // MIME type
+  show_reel?: boolean
+  reel_only?: boolean
 }
 
 export function getGalleryImages(): GalleryImage[] {


### PR DESCRIPTION
## Summary
- allow updating gallery and reel tags for existing images
- persist tag edits through new API patch handler
- expose tag toggles in gallery cards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68923644aa8c832d9c3cd85ddd323ab7