### PR TITLE
Refresh Google OAuth access token in memory

### DIFF
--- a/lib/authorize_google.ts
+++ b/lib/authorize_google.ts
@@ -2,27 +2,50 @@
 import { google } from 'googleapis';
 import dotenv from 'dotenv';
 
-//read the .env.local file
+dotenv.config({ path: '.env.local' });
+
+const CLIENT_ID = process.env.CLIENT_ID;
+const CLIENT_SECRET = process.env.CLIENT_SECRET;
+const REDIRECT_URI = process.env.REDIRECT_URI;
+const REFRESH_TOKEN = process.env.REFRESH_TOKEN;
+
+const oAuth2Client = new google.auth.OAuth2(
+  CLIENT_ID,
+  CLIENT_SECRET,
+  REDIRECT_URI
+);
+
+oAuth2Client.setCredentials({
+  refresh_token: REFRESH_TOKEN,
+});
+
+let currentAccessToken: string | null = null;
+
+async function refreshAccessToken() {
+  try {
+    const { token } = await oAuth2Client.getAccessToken();
+    currentAccessToken = token ?? null;
+    console.log('✅ Access token refreshed');
+  } catch (err) {
+    console.error('❌ Error refreshing token:', err);
+  }
+}
+
+refreshAccessToken();
+setInterval(refreshAccessToken, 50 * 60 * 1000);
+
 function authorize() {
-  dotenv.config({ path: '.env.local' });
-
-  const CLIENT_ID = process.env.CLIENT_ID;
-  const CLIENT_SECRET = process.env.CLIENT_SECRET;
-  const REDIRECT_URI = process.env.REDIRECT_URI;
-  const ACCESS_TOKEN = process.env.ACCESS_TOKEN;
-  const REFRESH_TOKEN = process.env.REFRESH_TOKEN;
-
-  const oAuth2Client = new google.auth.OAuth2(
-    CLIENT_ID,
-    CLIENT_SECRET,
-    REDIRECT_URI
-  );
-  oAuth2Client.setCredentials({
-    access_token: ACCESS_TOKEN,
-    refresh_token: REFRESH_TOKEN,
-  });
-
+  if (currentAccessToken) {
+    oAuth2Client.setCredentials({
+      access_token: currentAccessToken,
+      refresh_token: REFRESH_TOKEN,
+    });
+  }
   return oAuth2Client;
 }
 
-export { authorize };
+function getAccessToken() {
+  return currentAccessToken;
+}
+
+export { authorize, getAccessToken, oAuth2Client };


### PR DESCRIPTION
## Summary
- remove reliance on stored access token and derive it from refresh token
- periodically refresh Google OAuth access token and keep it in memory

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892355fa8c4832dbc84870188de5459