### PR TITLE
feat: add admin media management panel

### DIFF
--- a/app/api/image/[fileid]/route.ts
+++ b/app/api/image/[fileid]/route.ts
@@ -103,6 +103,10 @@ export async function PATCH(req: NextRequest, { params }) {
       typeof body.show_reel === "boolean" ? body.show_reel : existing.show_reel,
     reel_only:
       typeof body.reel_only === "boolean" ? body.reel_only : existing.reel_only,
+    title: typeof body.title === "string" ? body.title : existing.title,
+    description: typeof body.description === "string" ? body.description : existing.description,
+    year: typeof body.year === "string" ? body.year : existing.year,
+    alt: typeof body.alt === "string" ? body.alt : existing.alt,
   };
   await updateImage(updated);
   return NextResponse.json({ success: true });

--- a/app/api/video/[fileid]/route.ts
+++ b/app/api/video/[fileid]/route.ts
@@ -2,7 +2,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import path from "path";
 import fs from "fs";
-import { getVideoById } from "@/lib/store-utils";
+import { getVideoById, updateVideo, deleteVideo } from "@/lib/store-utils";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
 
 // @ts-expect-error: the normal type I would have assigned to params arg was recognized as type error by nextjs
 export async function GET(request: NextRequest, { params }) {
@@ -66,48 +68,78 @@ export async function GET(request: NextRequest, { params }) {
   }
 }
 
-// // @ts-expect-error: the normal type I would have assigned to params arg was recognized as type error by nextjs
-// export async function DELETE(_: NextRequest, { params }) {
-//   const { fileid } = await params;
-//   const image = await deleteImage(fileid);
-//   if (!image) {
-//     return NextResponse.json({ error: "Image not found" }, { status: 404 });
-//   }
-//   const filePath = path.join(process.cwd(), "uploads", image.src);
-//   if (!fs.existsSync(filePath)) {
-//     return NextResponse.json({ error: "File not found" }, { status: 404 });
-//   }
-//   try {
-//     fs.unlinkSync(filePath);
-//     return NextResponse.json({ success: true });
-  
-//   } catch (err) {
-//     return NextResponse.json({ error: "Failed to delete file" }, { status: 500 });
-//   }
-// }
+// @ts-expect-error: the normal type I would have assigned to params arg was recognized as type error by nextjs
+export async function DELETE(_: NextRequest, { params }) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { fileid } = params;
+  const video = await deleteVideo(fileid);
+  if (!video) {
+    return NextResponse.json({ error: "Video not found" }, { status: 404 });
+  }
+  const filePath = path.join(process.cwd(), "uploads", video.src);
+  if (fs.existsSync(filePath)) {
+    try {
+      fs.unlinkSync(filePath);
+    } catch {
+      return NextResponse.json({ error: "Failed to delete file" }, { status: 500 });
+    }
+  }
+  return NextResponse.json({ success: true });
+}
 
-// // @ts-expect-error: the normal type I would have assigned to params arg was recognized as type error by nextjs
-// export async function PUT(request: NextRequest, { params }) {
-//   const { fileid } = await params;
-//   const image = await getImageById(fileid);
-//   if (!image) {
-//     return NextResponse.json({ error: "Image not found" }, { status: 404 });
-//   } 
-//   const filePath = path.join(process.cwd(), "uploads", image.src);
-//   if (!fs.existsSync(filePath)) {
-//     return NextResponse.json({ error: "File not found" }, { status: 404 });
-//   }
-//   const formData = await request.formData();
-//   const file = formData.get("file");
-//   if (!file || typeof file === "string") {
-//     return NextResponse.json({ error: "No file uploaded" }, { status: 400 });
-//   }
-//   const arrayBuffer = await file.arrayBuffer();
-//   const buffer = Buffer.from(arrayBuffer);
-//   try {
-//     fs.writeFileSync(filePath, buffer);
-//     return NextResponse.json({ success: true });
-//   } catch (err) {
-//     return NextResponse.json({ error: "Failed to update file" }, { status: 500 });
-//   }
-// }
+// @ts-expect-error: the normal type I would have assigned to params arg was recognized as type error by nextjs
+export async function PUT(request: NextRequest, { params }) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { fileid } = params;
+  const video = await getVideoById(fileid);
+  if (!video) {
+    return NextResponse.json({ error: "Video not found" }, { status: 404 });
+  }
+  const filePath = path.join(process.cwd(), "uploads", video.src);
+  const formData = await request.formData();
+  const file = formData.get("file");
+  if (!file || typeof file === "string") {
+    return NextResponse.json({ error: "No file uploaded" }, { status: 400 });
+  }
+  const arrayBuffer = await file.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  try {
+    fs.writeFileSync(filePath, buffer);
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json({ error: "Failed to update file" }, { status: 500 });
+  }
+}
+
+// @ts-expect-error: the normal type I would have assigned to params arg was recognized as type error by nextjs
+export async function PATCH(req: NextRequest, { params }) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { fileid } = params;
+  const existing = await getVideoById(fileid);
+  if (!existing) {
+    return NextResponse.json({ error: "Video not found" }, { status: 404 });
+  }
+  const body = await req.json();
+  const updated = {
+    ...existing,
+    show_reel:
+      typeof body.show_reel === "boolean" ? body.show_reel : existing.show_reel,
+    reel_only:
+      typeof body.reel_only === "boolean" ? body.reel_only : existing.reel_only,
+    title: typeof body.title === "string" ? body.title : existing.title,
+    description: typeof body.description === "string" ? body.description : existing.description,
+    year: typeof body.year === "string" ? body.year : existing.year,
+    alt: typeof body.alt === "string" ? body.alt : existing.alt,
+  };
+  await updateVideo(updated);
+  return NextResponse.json({ success: true });
+}

--- a/components/admin-media-manager.tsx
+++ b/components/admin-media-manager.tsx
@@ -1,0 +1,183 @@
+"use client"
+
+import { useEffect, useState, useRef } from "react"
+import Image from "next/image"
+import { useSession } from "next-auth/react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+
+interface MediaItem {
+  id: string
+  src: string
+  alt: string
+  title: string
+  description: string
+  medium: "image" | "video"
+  year: string
+  show_reel?: boolean
+  reel_only?: boolean
+}
+
+interface DraftItem extends MediaItem {
+  file?: File
+}
+
+const visibilityOptions = [
+  { value: "gallery", label: "Solo galleria" },
+  { value: "reels", label: "Solo reels" },
+  { value: "both", label: "Entrambi" },
+  { value: "none", label: "Nessuno" }
+]
+
+export function AdminMediaManager() {
+  const { data: session } = useSession()
+  const [media, setMedia] = useState<DraftItem[]>([])
+  const fileInputs = useRef<{ [key: string]: HTMLInputElement | null }>({})
+
+  useEffect(() => {
+    if (session) {
+      fetchAll()
+    }
+  }, [session])
+
+  async function fetchAll() {
+    const [imgsRes, vidsRes] = await Promise.all([
+      fetch("/api/image?all=1"),
+      fetch("/api/video?all=1"),
+    ])
+    const [imgs, vids] = await Promise.all([imgsRes.json(), vidsRes.json()])
+    setMedia([...imgs, ...vids])
+  }
+
+  const visibilityValue = (item: MediaItem) => {
+    if (item.show_reel) {
+      return item.reel_only ? "reels" : "both"
+    }
+    return item.reel_only ? "none" : "gallery"
+  }
+
+  const handleVisibilityChange = (id: string, medium: string, value: string) => {
+    setMedia(prev =>
+      prev.map(item =>
+        item.id === id
+          ? {
+              ...item,
+              show_reel: value === "reels" || value === "both",
+              reel_only: value === "reels" || value === "none",
+            }
+          : item
+      )
+    )
+  }
+
+  const handleFieldChange = (id: string, field: keyof DraftItem, value: string) => {
+    setMedia(prev => prev.map(item => (item.id === id ? { ...item, [field]: value } : item)))
+  }
+
+  const handleFileChange = (id: string, file?: File) => {
+    setMedia(prev => prev.map(item => (item.id === id ? { ...item, file } : item)))
+  }
+
+  const saveItem = async (item: DraftItem) => {
+    await fetch(`/api/${item.medium}/${item.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: item.title,
+        description: item.description,
+        year: item.year,
+        alt: item.alt,
+        show_reel: item.show_reel,
+        reel_only: item.reel_only,
+      }),
+    })
+
+    if (item.file) {
+      const formData = new FormData()
+      formData.append("file", item.file)
+      await fetch(`/api/${item.medium}/${item.id}`, {
+        method: "PUT",
+        body: formData,
+      })
+    }
+    fetchAll()
+  }
+
+  if (!session) return null
+
+  return (
+    <section className="py-20 px-4 bg-gray-100">
+      <div className="max-w-6xl mx-auto space-y-8">
+        <h2 className="text-3xl font-bold text-center">Gestione Media</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {media.map(item => (
+            <Card key={item.id} className="overflow-hidden">
+              <div className="relative h-48 bg-gray-200">
+                {item.medium === "image" ? (
+                  <Image
+                    src={`/api/image/${item.id}`}
+                    alt={item.alt}
+                    fill
+                    className="object-cover"
+                  />
+                ) : (
+                  <video
+                    src={`/api/video/${item.id}`}
+                    className="w-full h-full object-cover"
+                    controls
+                  />
+                )}
+              </div>
+              <CardContent className="space-y-2 p-4">
+                <input
+                  type="text"
+                  value={item.title}
+                  onChange={e => handleFieldChange(item.id, "title", e.target.value)}
+                  className="w-full border rounded px-2 py-1"
+                />
+                <textarea
+                  value={item.description}
+                  onChange={e => handleFieldChange(item.id, "description", e.target.value)}
+                  className="w-full border rounded px-2 py-1"
+                />
+                <input
+                  type="text"
+                  value={item.year}
+                  onChange={e => handleFieldChange(item.id, "year", e.target.value)}
+                  className="w-full border rounded px-2 py-1"
+                />
+                <input
+                  type="text"
+                  value={item.alt}
+                  onChange={e => handleFieldChange(item.id, "alt", e.target.value)}
+                  className="w-full border rounded px-2 py-1"
+                />
+                <select
+                  value={visibilityValue(item)}
+                  onChange={e => handleVisibilityChange(item.id, item.medium, e.target.value)}
+                  className="w-full border rounded px-2 py-1"
+                >
+                  {visibilityOptions.map(opt => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  type="file"
+                  ref={el => (fileInputs.current[item.id] = el)}
+                  onChange={e => handleFileChange(item.id, e.target.files?.[0])}
+                  className="w-full"
+                />
+                <Button onClick={() => saveItem(item)} className="mt-2">
+                  Salva
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+

--- a/components/art-showcase.tsx
+++ b/components/art-showcase.tsx
@@ -6,6 +6,7 @@ import { ContactSection } from "./contact-section"
 import { FooterSection } from "./footer-section"
 import { CursorFollower } from "./cursor-follower"
 import { UnifiedGallery } from "./unified-gallery"
+import { AdminMediaManager } from "./admin-media-manager"
 import { useEffect, useState } from "react"
 import { LoginModal } from "./login-modal";
 import { SessionProvider } from "next-auth/react"
@@ -36,6 +37,7 @@ export function ArtShowcase() {
         <HeroSection />
       <AboutSection />
       <UnifiedGallery />
+      <AdminMediaManager />
       <ContactSection />
       <FooterSection onAdminClick={() => setShowModal(true)} />
 

--- a/components/gallery-content.tsx
+++ b/components/gallery-content.tsx
@@ -3,35 +3,13 @@
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { useEffect, useState, useRef } from "react"
+import { useEffect, useState } from "react"
 import { GalleryImage } from "@/lib/gallery"
-import { useSession } from "next-auth/react"
-
 
 export function GalleryContent() {
   const [images, setImages] = useState<GalleryImage[]>([])
   const [loading, setLoading] = useState(true)
   const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set())
-  const [addingNew, setAddingNew] = useState(false)
-  const [newMedia, setNewMedia] = useState({
-    title: "",
-    medium: "",
-    year: "",
-    description: "",
-    file: null as File | null,
-    alt: "",
-    gallery: true,
-    reels: false,
-  })
-  const [submitting, setSubmitting] = useState(false)
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  // Remove useFormState and server action logic
-  // const uploadImageReducer = async (state: any, formData: FormData) => {
-  //   return await uploadImage(formData)
-  // }
-  // const [formState, formAction] = useFormState(uploadImageReducer, null)
-  const [formState, setFormState] = useState<{ success?: boolean; error?: string } | null>(null);
-  const { data: session } = useSession();
 
   const toggleCardExpansion = (cardId: string) => {
     setExpandedCards(prev => {
@@ -50,102 +28,21 @@ export function GalleryContent() {
     return description.substring(0, maxLength).trim() + "..."
   }
 
-  const handleNewMediaChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    const { name, value, files, type, checked } = e.target as HTMLInputElement
-    if (name === "file" && files) {
-      setNewMedia((prev) => ({ ...prev, file: files[0] }))
-    } else if (type === "checkbox") {
-      setNewMedia((prev) => ({ ...prev, [name]: checked }))
-    } else {
-      setNewMedia((prev) => ({ ...prev, [name]: value }))
-    }
-  }
-
-  // Add a handler for form submission
-  const handleUploadSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setSubmitting(true);
-    setFormState(null);
-    const formData = new FormData();
-    if (newMedia.file) formData.append("file", newMedia.file);
-    formData.append("title", newMedia.title);
-    formData.append("medium", newMedia.medium);
-    formData.append("year", newMedia.year);
-    formData.append("description", newMedia.description);
-    formData.append("alt", newMedia.alt);
-    formData.append("show_reel", String(newMedia.reels));
-    formData.append("reel_only", String(newMedia.reels && !newMedia.gallery));
-    try {
-      const isVideo = newMedia.file?.type.startsWith("video");
-      const res = await fetch(isVideo ? "/api/video" : "/api/image", {
-        method: "POST",
-        body: formData,
-        cache: "no-store",
-      });
-      const data = await res.json();
-      if (data.success) {
-        setFormState({ success: true });
-        fetchImages();
-        setNewMedia({
-          title: "",
-          medium: "",
-          year: "",
-          description: "",
-          file: null,
-          alt: "",
-          gallery: true,
-          reels: false,
-        });
-        setAddingNew(false);
-      } else {
-        setFormState({ error: data.error || "Errore durante il caricamento." });
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (_) {
-      setFormState({ error: "Errore di rete." });
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  // Move fetchImages outside useEffect so it can be called elsewhere
   async function fetchImages() {
     try {
-      const res = await fetch("/api/image");
-      const data = await res.json();
-      setImages(data);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (_) {
-      setImages([]);
+      const res = await fetch("/api/image")
+      const data = await res.json()
+      setImages(data)
+    } catch {
+      setImages([])
     } finally {
-      setLoading(false);
-    }
-  }
-
-  async function updateTags(id: string, gallery: boolean, reels: boolean) {
-    try {
-      await fetch(`/api/image/${id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          show_reel: reels,
-          reel_only: reels && !gallery,
-        }),
-      });
-      fetchImages();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (_) {
-      /* ignore errors */
+      setLoading(false)
     }
   }
 
   useEffect(() => {
-    fetchImages();
-  }, []);
-
-
+    fetchImages()
+  }, [])
 
   if (loading) {
     return (
@@ -155,17 +52,17 @@ export function GalleryContent() {
     )
   }
 
-  
   return (
     <div className="space-y-8">
       <p className="text-lg text-center max-w-3xl mx-auto text-gray-700">
-        Esplora una selezione di opere uniche e curate. Ogni opera racconta una storia e è progettata per trasformare gli spazi con eleganza e autenticità.
+        Esplora una selezione di opere uniche e curate. Ogni opera racconta una storia e è progettata per trasformare gli spazi
+        con eleganza e autenticità.
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
         {images.map((image) => {
           const isExpanded = expandedCards.has(image.id)
           const displayDescription = isExpanded ? image.description : truncateDescription(image.description)
-          
+
           return (
             <Card
               key={image.id}
@@ -186,8 +83,8 @@ export function GalleryContent() {
                 <p className="text-gray-600 text-sm">{image.medium}, {image.year}</p>
                 <p className="text-gray-700">{displayDescription}</p>
                 {image.description.length > 150 && (
-                  <><Button 
-                    variant="link" 
+                  <><Button
+                    variant="link"
                     className="p-0 h-auto text-primary-tan hover:text-primary-tan/80"
                     onClick={() => toggleCardExpansion(image.id)}
                   >
@@ -197,196 +94,11 @@ export function GalleryContent() {
                 <Button variant="link" className="p-0 h-auto text-primary-tan hover:text-primary-tan/80">
                   Scopri di più
                 </Button>
-                {session && (
-                  <div className="flex flex-col gap-2 mt-2">
-                    <div className="flex gap-4">
-                      <label className="flex items-center gap-2">
-                        <input
-                          type="checkbox"
-                          checked={!image.reel_only}
-                          onChange={(e) =>
-                            updateTags(image.id, e.target.checked, image.show_reel === true)
-                          }
-                        />
-                        Gallery
-                      </label>
-                      <label className="flex items-center gap-2">
-                        <input
-                          type="checkbox"
-                          checked={image.show_reel === true}
-                          onChange={(e) =>
-                            updateTags(image.id, !image.reel_only, e.target.checked)
-                          }
-                        />
-                        Reels
-                      </label>
-                    </div>
-                    <div className="flex gap-2">
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        onClick={async () => {
-                          if (confirm("Sei sicuro di voler eliminare questa immagine?")) {
-                            const res = await fetch(`/api/image/${image.id}`, { method: "DELETE" });
-                            if (res.ok) fetchImages();
-                          }
-                        }}
-                      >
-                        Elimina
-                      </Button>
-                      <label className="inline-block">
-                        <input
-                          type="file"
-                          accept="image/*"
-                          style={{ display: "none" }}
-                          onChange={async (e) => {
-                            const file = e.target.files?.[0];
-                            if (!file) return;
-                            const formData = new FormData();
-                            formData.append("file", file);
-                            const res = await fetch(`/api/image/${image.id}`, {
-                              method: "PUT",
-                              body: formData,
-                            });
-                            if (res.ok) fetchImages();
-                          }}
-                        />
-                        <Button asChild variant="secondary" size="sm">
-                          <span>Modifica</span>
-                        </Button>
-                      </label>
-                    </div>
-                  </div>
-                )}
               </CardContent>
             </Card>
           )
         })}
-        {session && (
-          addingNew ? (
-            <form onSubmit={handleUploadSubmit} className="flex flex-col justify-between h-full w-full">
-              <Card className="overflow-hidden rounded-lg shadow-lg bg-white">
-                <div className="relative overflow-hidden flex items-center justify-center h-60 bg-gray-100">
-                  {newMedia.file ? (
-                    newMedia.file.type.startsWith("video") ? (
-                      <video
-                        src={URL.createObjectURL(newMedia.file)}
-                        className="w-full h-60 object-cover"
-                        controls
-                      />
-                    ) : (
-                      <Image
-                        src={URL.createObjectURL(newMedia.file)}
-                        width={400}
-                        height={300}
-                        alt={newMedia.alt || "preview"}
-                        className="w-full h-60 object-cover"
-                      />
-                    )
-                  ) : (
-                    <span className="text-gray-400">Anteprima media</span>
-                  )}
-                </div>
-                <CardContent className="p-6 space-y-2">
-                  <input
-                    type="file"
-                    name="file"
-                    accept="image/*,video/*"
-                    ref={fileInputRef}
-                    onChange={handleNewMediaChange}
-                    className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-primary-tan/20 file:text-primary-tan hover:file:bg-primary-tan/40"
-                    required
-                  />
-                  <div className="flex gap-4 mt-2">
-                    <label className="flex items-center gap-2">
-                      <input
-                        type="checkbox"
-                        name="gallery"
-                        checked={newMedia.gallery}
-                        onChange={handleNewMediaChange}
-                      />
-                      Gallery
-                    </label>
-                    <label className="flex items-center gap-2">
-                      <input
-                        type="checkbox"
-                        name="reels"
-                        checked={newMedia.reels}
-                        onChange={handleNewMediaChange}
-                      />
-                      Reels
-                    </label>
-                  </div>
-                  <input
-                    type="text"
-                    name="title"
-                    placeholder="Titolo"
-                    value={newMedia.title}
-                    onChange={handleNewMediaChange}
-                    className="w-full border rounded px-2 py-1 mt-2"
-                    required
-                  />
-                  <input
-                    type="text"
-                    name="medium"
-                    placeholder="Tecnica"
-                    value={newMedia.medium}
-                    onChange={handleNewMediaChange}
-                    className="w-full border rounded px-2 py-1"
-                    required
-                  />
-                  <input
-                    type="text"
-                    name="year"
-                    placeholder="Anno"
-                    value={newMedia.year}
-                    onChange={handleNewMediaChange}
-                    className="w-full border rounded px-2 py-1"
-                    required
-                  />
-                  <input
-                    type="text"
-                    name="alt"
-                    placeholder="Testo alternativo"
-                    value={newMedia.alt}
-                    onChange={handleNewMediaChange}
-                    className="w-full border rounded px-2 py-1"
-                  />
-                  <textarea
-                    name="description"
-                    placeholder="Descrizione"
-                    value={newMedia.description}
-                    onChange={handleNewMediaChange}
-                    className="w-full border rounded px-2 py-1"
-                    required
-                  />
-                  <div className="flex gap-2 mt-2">
-                    <Button type="submit" className="text-white border-primary-tan" disabled={submitting}>
-                      Carica
-                    </Button>
-                    <Button type="button" variant="outline" onClick={() => setAddingNew(false)}>
-                      Annulla
-                    </Button>
-                  </div>
-                  {formState?.error && <div className="text-red-500 text-sm mt-2">{formState.error}</div>}
-                  {formState?.success && <div className="text-green-600 text-sm mt-2">Media caricato!</div>}
-                </CardContent>
-              </Card>
-            </form>
-          ) : (
-            <div className="flex items-center justify-center h-full">
-              <Button
-                variant="outline"
-                className="w-full h-60 text-4xl font-bold text-primary-tan border-2 border-primary-tan hover:bg-primary-tan/10"
-                aria-label="Aggiungi nuovo media"
-                onClick={() => setAddingNew(true)}
-              >
-                +
-              </Button>
-            </div>
-          )
-        )}
       </div>
     </div>
   )
-} 
+}

--- a/components/reels-content.tsx
+++ b/components/reels-content.tsx
@@ -3,8 +3,6 @@
 import { useState, useEffect, useRef, useCallback } from "react"
 import Image from "next/image"
 import { ChevronUp, ChevronDown, Play, Pause, ChevronUp as ExpandIcon, ChevronDown as CollapseIcon } from "lucide-react"
-import { useSession } from "next-auth/react"
-import { Button } from "@/components/ui/button"
 
 interface ReelMedia {
   id: string
@@ -27,10 +25,7 @@ export function ReelsContent() {
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const videoRefs = useRef<{ [key: string]: HTMLVideoElement | null }>({})
-  const { data: session } = useSession()
   const [reelsMedia, setReelsMedia] = useState<ReelMedia[]>([])
-  const [allMedia, setAllMedia] = useState<ReelMedia[]>([])
-  const [menuOpen, setMenuOpen] = useState(false)
 
   const fetchReels = async () => {
     const res = await fetch("/api/reel")
@@ -41,14 +36,6 @@ export function ReelsContent() {
     )
   }
 
-  const fetchAllMedia = async () => {
-    const [imgsRes, vidsRes] = await Promise.all([
-      fetch("/api/image?all=1"),
-      fetch("/api/video?all=1"),
-    ])
-    const [imgs, vids] = await Promise.all([imgsRes.json(), vidsRes.json()])
-    setAllMedia([...imgs, ...vids])
-  }
 
   const nextReel = useCallback(() => {
     if (reelsMedia.length === 0) return
@@ -180,25 +167,6 @@ export function ReelsContent() {
 
   return (
     <div className="space-y-8">
-      {session && (
-        <div className="w-full flex justify-center">
-          <Button
-            variant="secondary"
-            size="sm"
-            className="flex items-center space-x-2 text-sm font-medium shadow-sm"
-            onClick={() => {
-              const open = !menuOpen
-              setMenuOpen(open)
-              if (open) fetchAllMedia()
-            }}
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h7" />
-            </svg>
-            <span>Gestione contenuti Reels</span>
-          </Button>
-        </div>
-      )}
       {currentMedia ? <>
       <div 
         ref={containerRef}
@@ -360,60 +328,6 @@ export function ReelsContent() {
       <div className="flex justify-center py-12">
         <div className="text-gray-600">Nessun media disponibile.</div>
       </div>}
-      {menuOpen && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white p-4 rounded max-h-[80vh] overflow-y-auto">
-            <h2 className="text-lg mb-4">Seleziona media da mostrare</h2>
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-              {allMedia.map((m) => (
-                <label key={m.id} className="flex flex-col items-center">
-                  {m.medium === "image" ? (
-                    <Image
-                      src={`/api/image/${m.id}`}
-                      alt={m.alt}
-                      width={100}
-                      height={100}
-                      className="object-cover"
-                    />
-                  ) : (
-                    <video
-                      src={`/api/video/${m.id}`}
-                      className="w-[100px] h-[100px] object-cover"
-                      muted
-                      loop
-                      playsInline
-                    />
-                  )}
-                  <input
-                    type="checkbox"
-                    className="mt-2"
-                    checked={m.show_reel === true}
-                    onChange={async (e) => {
-                      const checked = e.target.checked
-                      await fetch(`/api/reel/${m.id}`, {
-                        method: "PUT",
-                        headers: { "Content-Type": "application/json" },
-                        body: JSON.stringify({ show_reel: checked }),
-                      })
-                      await fetchReels()
-                      setAllMedia((prev) =>
-                        prev.map((item) =>
-                          item.id === m.id ? { ...item, show_reel: checked } : item
-                        )
-                      )
-                    }}
-                  />
-                </label>
-              ))}
-            </div>
-            <div className="mt-4 text-right">
-              <Button size="sm" onClick={() => setMenuOpen(false)}>
-                Chiudi
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/lib/store-utils.ts
+++ b/lib/store-utils.ts
@@ -79,3 +79,19 @@ export const addVideo = async (video: ImageRecord): Promise<void> => {
   const collection = await getCollection<ImageRecord>(collectionName);
   await collection.insertOne(video);
 };
+
+export const updateVideo = async (video: ImageRecord): Promise<ImageRecord | null> => {
+  const collection = await getCollection<ImageRecord>(collectionName);
+  const result = await collection.findOneAndUpdate(
+    { id: video.id, medium: "video" },
+    { $set: video },
+    { returnDocument: "before" }
+  );
+  return result ?? null;
+};
+
+export const deleteVideo = async (id: string): Promise<ImageRecord | null> => {
+  const collection = await getCollection<ImageRecord>(collectionName);
+  const result = await collection.findOneAndDelete({ id, medium: "video" });
+  return result ?? null;
+};


### PR DESCRIPTION
## Summary
- add admin panel to manage all media entries in one place
- strip editing options from gallery and reels sections
- support updating media metadata and files via API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689373da3ab0832d959b43724ba44ea1