### PR TITLE
Ensure gallery and reels refresh after admin media updates

### DIFF
--- a/components/admin-media-manager.tsx
+++ b/components/admin-media-manager.tsx
@@ -100,7 +100,8 @@ export function AdminMediaManager() {
         body: formData,
       })
     }
-    fetchAll()
+    await fetchAll()
+    window.dispatchEvent(new Event("mediaUpdated"))
   }
 
   if (!session) return null

--- a/components/gallery-content.tsx
+++ b/components/gallery-content.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { useEffect, useState } from "react"
+import { useEffect, useState, useCallback } from "react"
 import { GalleryImage } from "@/lib/gallery"
 
 export function GalleryContent() {
@@ -28,7 +28,7 @@ export function GalleryContent() {
     return description.substring(0, maxLength).trim() + "..."
   }
 
-  async function fetchImages() {
+  const fetchImages = useCallback(async () => {
     try {
       const res = await fetch("/api/image")
       const data = await res.json()
@@ -38,11 +38,14 @@ export function GalleryContent() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [])
 
   useEffect(() => {
     fetchImages()
-  }, [])
+    const handleUpdate = () => fetchImages()
+    window.addEventListener("mediaUpdated", handleUpdate)
+    return () => window.removeEventListener("mediaUpdated", handleUpdate)
+  }, [fetchImages])
 
   if (loading) {
     return (

--- a/components/reels-content.tsx
+++ b/components/reels-content.tsx
@@ -27,14 +27,14 @@ export function ReelsContent() {
   const videoRefs = useRef<{ [key: string]: HTMLVideoElement | null }>({})
   const [reelsMedia, setReelsMedia] = useState<ReelMedia[]>([])
 
-  const fetchReels = async () => {
+  const fetchReels = useCallback(async () => {
     const res = await fetch("/api/reel")
     const data = await res.json()
     setReelsMedia(data)
     setCurrentIndex((prev) =>
       data.length > 0 ? Math.min(prev, data.length - 1) : 0
     )
-  }
+  }, [])
 
 
   const nextReel = useCallback(() => {
@@ -67,7 +67,10 @@ export function ReelsContent() {
   useEffect(() => {
     setIsMounted(true)
     fetchReels()
-  }, [])
+    const handleUpdate = () => fetchReels()
+    window.addEventListener("mediaUpdated", handleUpdate)
+    return () => window.removeEventListener("mediaUpdated", handleUpdate)
+  }, [fetchReels])
 
   useEffect(() => {
     if (reelsMedia.length === 0) return


### PR DESCRIPTION
## Summary
- Dispatch a `mediaUpdated` event after saving media in the admin manager
- Re-fetch gallery and reel data when the `mediaUpdated` event fires

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68937a110b6c832d93a155653d84ebce