### PR TITLE
style: improve admin media manager and login UI

### DIFF
--- a/components/admin-media-manager.tsx
+++ b/components/admin-media-manager.tsx
@@ -5,6 +5,8 @@ import Image from "next/image"
 import { useSession } from "next-auth/react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Badge } from "@/components/ui/badge"
 
 interface MediaItem {
   id: string
@@ -33,6 +35,7 @@ export function AdminMediaManager() {
   const { data: session } = useSession()
   const [media, setMedia] = useState<DraftItem[]>([])
   const fileInputs = useRef<{ [key: string]: HTMLInputElement | null }>({})
+  const [loadedImages, setLoadedImages] = useState<Record<string, boolean>>({})
 
   useEffect(() => {
     if (session) {
@@ -115,12 +118,20 @@ export function AdminMediaManager() {
             <Card key={item.id} className="overflow-hidden">
               <div className="relative h-48 bg-gray-200">
                 {item.medium === "image" ? (
-                  <Image
-                    src={`/api/image/${item.id}`}
-                    alt={item.alt}
-                    fill
-                    className="object-cover"
-                  />
+                  <>
+                    {!loadedImages[item.id] && (
+                      <Skeleton className="absolute inset-0 h-full w-full" />
+                    )}
+                    <Image
+                      src={`/api/image/${item.id}`}
+                      alt={item.alt}
+                      fill
+                      onLoadingComplete={() =>
+                        setLoadedImages(prev => ({ ...prev, [item.id]: true }))
+                      }
+                      className="object-cover"
+                    />
+                  </>
                 ) : (
                   <video
                     src={`/api/video/${item.id}`}
@@ -153,23 +164,57 @@ export function AdminMediaManager() {
                   onChange={e => handleFieldChange(item.id, "alt", e.target.value)}
                   className="w-full border rounded px-2 py-1"
                 />
-                <select
-                  value={visibilityValue(item)}
-                  onChange={e => handleVisibilityChange(item.id, item.medium, e.target.value)}
-                  className="w-full border rounded px-2 py-1"
-                >
-                  {visibilityOptions.map(opt => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
-                <input
-                  type="file"
-                  ref={el => (fileInputs.current[item.id] = el)}
-                  onChange={e => handleFileChange(item.id, e.target.files?.[0])}
-                  className="w-full"
-                />
+                <div className="flex flex-wrap gap-2">
+                  {visibilityOptions.map(opt => {
+                    const selected = visibilityValue(item) === opt.value
+                    const colorMap: Record<string, string> = {
+                      gallery: "bg-green-500 text-white hover:bg-green-600",
+                      reels: "bg-blue-500 text-white hover:bg-blue-600",
+                      both: "bg-purple-500 text-white hover:bg-purple-600",
+                      none: "bg-gray-300 text-gray-800 hover:bg-gray-400",
+                    }
+                    const unselectedMap: Record<string, string> = {
+                      gallery: "text-green-600 border-green-600 hover:bg-green-50",
+                      reels: "text-blue-600 border-blue-600 hover:bg-blue-50",
+                      both: "text-purple-600 border-purple-600 hover:bg-purple-50",
+                      none: "text-gray-600 border-gray-600 hover:bg-gray-50",
+                    }
+                    const classes = selected
+                      ? colorMap[opt.value]
+                      : `border ${unselectedMap[opt.value]}`
+                    return (
+                      <Badge
+                        key={opt.value}
+                        onClick={() =>
+                          handleVisibilityChange(item.id, item.medium, opt.value)
+                        }
+                        className={`cursor-pointer ${classes}`}
+                      >
+                        {opt.label}
+                      </Badge>
+                    )
+                  })}
+                </div>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="file"
+                    ref={el => (fileInputs.current[item.id] = el)}
+                    onChange={e => handleFileChange(item.id, e.target.files?.[0])}
+                    className="hidden"
+                  />
+                  <Button
+                    variant="outline"
+                    type="button"
+                    onClick={() => fileInputs.current[item.id]?.click()}
+                  >
+                    Seleziona file
+                  </Button>
+                  {item.file && (
+                    <span className="text-sm text-gray-600 truncate">
+                      {item.file.name}
+                    </span>
+                  )}
+                </div>
                 <Button onClick={() => saveItem(item)} className="mt-2">
                   Salva
                 </Button>

--- a/components/gallery-content.tsx
+++ b/components/gallery-content.tsx
@@ -5,11 +5,13 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { useEffect, useState, useCallback } from "react"
 import { GalleryImage } from "@/lib/gallery"
+import { Skeleton } from "@/components/ui/skeleton"
 
 export function GalleryContent() {
   const [images, setImages] = useState<GalleryImage[]>([])
   const [loading, setLoading] = useState(true)
   const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set())
+  const [loadedImages, setLoadedImages] = useState<Record<string, boolean>>({})
 
   const toggleCardExpansion = (cardId: string) => {
     setExpandedCards(prev => {
@@ -71,12 +73,18 @@ export function GalleryContent() {
               key={image.id}
               className="overflow-hidden rounded-lg shadow-lg hover:shadow-xl transition-shadow duration-300 bg-white group"
             >
-              <div className="relative overflow-hidden">
+              <div className="relative overflow-hidden h-60">
+                {!loadedImages[image.id] && (
+                  <Skeleton className="absolute inset-0 h-full w-full" />
+                )}
                 <Image
                   src={`/api/image/${image.id}?cb=${Date.now()}`}
                   width={400}
                   height={300}
                   alt={image.alt}
+                  onLoadingComplete={() =>
+                    setLoadedImages(prev => ({ ...prev, [image.id]: true }))
+                  }
                   className="w-full h-60 object-cover"
                 />
                 <div className="absolute inset-0 bg-black/30 transition-opacity duration-300 group-hover:opacity-0"></div>

--- a/components/login-modal.tsx
+++ b/components/login-modal.tsx
@@ -1,6 +1,9 @@
 "use client";
 import React, { useState, useTransition } from "react";
 import { signIn } from "next-auth/react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 interface LoginModalProps {
   open: boolean;
@@ -37,8 +40,8 @@ export const LoginModal: React.FC<LoginModalProps> = ({ open, onClose }) => {
   }
 
   return (
-    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/30 backdrop-blur-sm transition-opacity duration-200 font-inter">
-      <div className="bg-white-shade p-8 shadow-2xl w-full max-w-sm border border-gray-200 text-gray-800 relative animate-fadeIn">
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/30 backdrop-blur-sm font-inter">
+      <Card className="w-full max-w-sm relative animate-fadeIn">
         <button
           className="absolute top-3 right-3 text-gray-400 hover:text-gray-600 transition-colors text-xl font-bold focus:outline-none focus:ring-2 focus:ring-gray-400 rounded-full"
           onClick={onClose}
@@ -47,33 +50,33 @@ export const LoginModal: React.FC<LoginModalProps> = ({ open, onClose }) => {
         >
           ×
         </button>
-        <h2 className="text-2xl font-bold mb-6 text-center">Login</h2>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="text"
-            name="username"
-            placeholder="Username"
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-400 bg-white text-gray-800 placeholder-gray-400 transition"
-            autoComplete="username"
-            disabled={isPending}
-          />
-          <input
-            type="password"
-            name="password"
-            placeholder="Password"
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-400 bg-white text-gray-800 placeholder-gray-400 transition"
-            autoComplete="current-password"
-            disabled={isPending}
-          />
-          <button
-            type="submit"
-            className="w-full bg-gray-800 text-white py-2 rounded-lg font-semibold hover:bg-gray-700 transition focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:opacity-60"
-            disabled={isPending}
-          >
-            {isPending ? "Logging in..." : "Login"}
-          </button>
-        </form>
-        {error && <div className="mt-4 text-red-600 text-center">{error}</div>}
+        <CardHeader>
+          <CardTitle className="text-center text-2xl">Login</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              type="text"
+              name="username"
+              placeholder="Username"
+              autoComplete="username"
+              disabled={isPending}
+            />
+            <Input
+              type="password"
+              name="password"
+              placeholder="Password"
+              autoComplete="current-password"
+              disabled={isPending}
+            />
+            {error && (
+              <div className="text-sm text-red-600 text-center">{error}</div>
+            )}
+            <Button type="submit" className="w-full" disabled={isPending}>
+              {isPending ? "Logging in..." : "Login"}
+            </Button>
+          </form>
+        </CardContent>
         <style jsx>{`
           @keyframes fadeIn {
             from { opacity: 0; transform: scale(0.97); }
@@ -83,7 +86,7 @@ export const LoginModal: React.FC<LoginModalProps> = ({ open, onClose }) => {
             animation: fadeIn 0.2s ease;
           }
         `}</style>
-      </div>
+      </Card>
     </div>
   );
-}; 
+};

--- a/components/reels-content.tsx
+++ b/components/reels-content.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react"
 import Image from "next/image"
+import { Skeleton } from "@/components/ui/skeleton"
 import { ChevronUp, ChevronDown, Play, Pause, ChevronUp as ExpandIcon, ChevronDown as CollapseIcon } from "lucide-react"
 
 interface ReelMedia {
@@ -21,6 +22,7 @@ export function ReelsContent() {
   const [isAutoPlay, setIsAutoPlay] = useState(true)
   const [videoError, setVideoError] = useState<string | null>(null)
   const [videoLoading, setVideoLoading] = useState(false)
+  const [imageLoaded, setImageLoaded] = useState(false)
   const [isMounted, setIsMounted] = useState(false)
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -120,6 +122,10 @@ export function ReelsContent() {
   }, [isAutoPlay, reelsMedia.length, isMounted, currentIndex, reelsMedia])
 
   useEffect(() => {
+    setImageLoaded(false)
+  }, [currentIndex])
+
+  useEffect(() => {
     // Handle video playback
     if (!isMounted || reelsMedia.length === 0 || reelsMedia[currentIndex]===undefined) return
 
@@ -178,13 +184,19 @@ export function ReelsContent() {
         {/* Current Media Display */}
         <div className="relative w-full h-full">
           {currentMedia.medium === "image" ? (
-            <Image
-              src={`/api/image/${currentMedia.id}`}
-              alt={currentMedia.alt}
-              fill
-              className="object-cover"
-              priority
-            />
+            <>
+              {!imageLoaded && (
+                <Skeleton className="absolute inset-0 h-full w-full" />
+              )}
+              <Image
+                src={`/api/image/${currentMedia.id}`}
+                alt={currentMedia.alt}
+                fill
+                onLoadingComplete={() => setImageLoaded(true)}
+                className="object-cover"
+                priority
+              />
+            </>
           ) : (
             <>
               <video

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,34 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+import * as React from "react"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary: "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        outline: "border border-input text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,7 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("animate-pulse rounded-md bg-gray-300", className)} {...props} />
+}
+
+export { Skeleton }


### PR DESCRIPTION
## Summary
- restyle admin media manager with color-coded visibility tags and a button-based file selector
- add skeleton placeholders for loading media and a reusable Skeleton component
- refresh login modal with design-system components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68937f4128dc832da250c367c182fc67