### PR TITLE
feat: enhance ui styling and media management

### DIFF
--- a/components/about-section.tsx
+++ b/components/about-section.tsx
@@ -1,8 +1,11 @@
 "use client"
 
 import Image from "next/image"
+import { useState } from "react"
+import { Skeleton } from "@/components/ui/skeleton"
 
 export function AboutSection() {
+  const [loaded, setLoaded] = useState(false)
   return (
     <section id="about" className="relative py-20 px-4 bg-primary-tan text-white overflow-hidden">
       {/* Subtle background stripes */}
@@ -28,12 +31,14 @@ export function AboutSection() {
         </div>
         <div className="flex justify-center">
           <div className="w-90 h-90 rounded-full border-4 border-white shadow-xl overflow-hidden relative">
+            {!loaded && <Skeleton className="absolute inset-0 h-full w-full rounded-full" />}
             <Image
               src="/assets/picprofile.JPG"
               width={500}
               height={500}
               alt="Artist's portrait"
               className="w-full h-full object-cover"
+              onLoadingComplete={() => setLoaded(true)}
             />
             <div className="absolute inset-0 bg-black/20 rounded-full"></div>
           </div>

--- a/components/admin-media-manager.tsx
+++ b/components/admin-media-manager.tsx
@@ -5,6 +5,8 @@ import Image from "next/image"
 import { useSession } from "next-auth/react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
 
 interface MediaItem {
   id: string
@@ -32,6 +34,8 @@ const visibilityOptions = [
 export function AdminMediaManager() {
   const { data: session } = useSession()
   const [media, setMedia] = useState<DraftItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadedPreview, setLoadedPreview] = useState<{ [key: string]: boolean }>({})
   const fileInputs = useRef<{ [key: string]: HTMLInputElement | null }>({})
 
   useEffect(() => {
@@ -41,12 +45,14 @@ export function AdminMediaManager() {
   }, [session])
 
   async function fetchAll() {
+    setLoading(true)
     const [imgsRes, vidsRes] = await Promise.all([
       fetch("/api/image?all=1"),
       fetch("/api/video?all=1"),
     ])
     const [imgs, vids] = await Promise.all([imgsRes.json(), vidsRes.json()])
     setMedia([...imgs, ...vids])
+    setLoading(false)
   }
 
   const visibilityValue = (item: MediaItem) => {
@@ -106,77 +112,132 @@ export function AdminMediaManager() {
 
   if (!session) return null
 
+  const tagStyles: Record<string, string> = {
+    gallery: "bg-blue-100 text-blue-800 hover:bg-blue-200",
+    reels: "bg-green-100 text-green-800 hover:bg-green-200",
+    both: "bg-purple-100 text-purple-800 hover:bg-purple-200",
+    none: "bg-gray-100 text-gray-800 hover:bg-gray-200",
+  }
+
   return (
     <section className="py-20 px-4 bg-gray-100">
       <div className="max-w-6xl mx-auto space-y-8">
         <h2 className="text-3xl font-bold text-center">Gestione Media</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {media.map(item => (
-            <Card key={item.id} className="overflow-hidden">
-              <div className="relative h-48 bg-gray-200">
-                {item.medium === "image" ? (
-                  <Image
-                    src={`/api/image/${item.id}`}
-                    alt={item.alt}
-                    fill
-                    className="object-cover"
+        {loading ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Card key={i} className="overflow-hidden">
+                <Skeleton className="h-48 w-full" />
+                <CardContent className="space-y-2 p-4">
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-24 w-full" />
+                  <Skeleton className="h-4 w-1/2" />
+                  <Skeleton className="h-4 w-1/3" />
+                  <div className="flex gap-2">
+                    {visibilityOptions.map(opt => (
+                      <Skeleton key={opt.value} className="h-6 w-16" />
+                    ))}
+                  </div>
+                  <Skeleton className="h-9 w-24" />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {media.map(item => (
+              <Card key={item.id} className="overflow-hidden">
+                <div className="relative h-48 bg-gray-200">
+                  {!loadedPreview[item.id] && <Skeleton className="absolute inset-0 h-full w-full" />}
+                  {item.medium === "image" ? (
+                    <Image
+                      src={`/api/image/${item.id}`}
+                      alt={item.alt}
+                      fill
+                      className="object-cover"
+                      onLoadingComplete={() =>
+                        setLoadedPreview(prev => ({ ...prev, [item.id]: true }))
+                      }
+                    />
+                  ) : (
+                    <video
+                      src={`/api/video/${item.id}`}
+                      className="w-full h-full object-cover"
+                      controls
+                      onLoadedData={() =>
+                        setLoadedPreview(prev => ({ ...prev, [item.id]: true }))
+                      }
+                    />
+                  )}
+                </div>
+                <CardContent className="space-y-2 p-4">
+                  <Input
+                    type="text"
+                    value={item.title}
+                    onChange={e => handleFieldChange(item.id, "title", e.target.value)}
                   />
-                ) : (
-                  <video
-                    src={`/api/video/${item.id}`}
-                    className="w-full h-full object-cover"
-                    controls
+                  <textarea
+                    value={item.description}
+                    onChange={e => handleFieldChange(item.id, "description", e.target.value)}
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
                   />
-                )}
-              </div>
-              <CardContent className="space-y-2 p-4">
-                <input
-                  type="text"
-                  value={item.title}
-                  onChange={e => handleFieldChange(item.id, "title", e.target.value)}
-                  className="w-full border rounded px-2 py-1"
-                />
-                <textarea
-                  value={item.description}
-                  onChange={e => handleFieldChange(item.id, "description", e.target.value)}
-                  className="w-full border rounded px-2 py-1"
-                />
-                <input
-                  type="text"
-                  value={item.year}
-                  onChange={e => handleFieldChange(item.id, "year", e.target.value)}
-                  className="w-full border rounded px-2 py-1"
-                />
-                <input
-                  type="text"
-                  value={item.alt}
-                  onChange={e => handleFieldChange(item.id, "alt", e.target.value)}
-                  className="w-full border rounded px-2 py-1"
-                />
-                <select
-                  value={visibilityValue(item)}
-                  onChange={e => handleVisibilityChange(item.id, item.medium, e.target.value)}
-                  className="w-full border rounded px-2 py-1"
-                >
-                  {visibilityOptions.map(opt => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
-                <input
-                  type="file"
-                  ref={el => (fileInputs.current[item.id] = el)}
-                  onChange={e => handleFileChange(item.id, e.target.files?.[0])}
-                  className="w-full"
-                />
-                <Button onClick={() => saveItem(item)} className="mt-2">
-                  Salva
-                </Button>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+                  <Input
+                    type="text"
+                    value={item.year}
+                    onChange={e => handleFieldChange(item.id, "year", e.target.value)}
+                  />
+                  <Input
+                    type="text"
+                    value={item.alt}
+                    onChange={e => handleFieldChange(item.id, "alt", e.target.value)}
+                  />
+                  <div className="flex flex-wrap gap-2 py-1">
+                    {visibilityOptions.map(opt => {
+                      const selected = visibilityValue(item) === opt.value
+                      return (
+                        <Button
+                          key={opt.value}
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() =>
+                            handleVisibilityChange(item.id, item.medium, opt.value)
+                          }
+                          className={
+                            "rounded-full px-2 py-1 text-xs " +
+                            tagStyles[opt.value] +
+                            (selected ? " ring-2 ring-offset-2 ring-gray-400" : " opacity-60")
+                          }
+                        >
+                          {opt.label}
+                        </Button>
+                      )
+                    })}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="file"
+                      ref={el => (fileInputs.current[item.id] = el)}
+                      onChange={e => handleFileChange(item.id, e.target.files?.[0])}
+                      className="hidden"
+                    />
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={() => fileInputs.current[item.id]?.click()}
+                    >
+                      {item.file ? "Cambiato" : "Seleziona file"}
+                    </Button>
+                    {item.file && <span className="text-xs text-gray-600">{item.file.name}</span>}
+                  </div>
+                  <Button onClick={() => saveItem(item)} className="mt-2">
+                    Salva
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
       </div>
     </section>
   )

--- a/components/gallery-content.tsx
+++ b/components/gallery-content.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
 import { useEffect, useState, useCallback } from "react"
 import { GalleryImage } from "@/lib/gallery"
 
@@ -10,6 +11,7 @@ export function GalleryContent() {
   const [images, setImages] = useState<GalleryImage[]>([])
   const [loading, setLoading] = useState(true)
   const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set())
+  const [loadedPreview, setLoadedPreview] = useState<{ [key: string]: boolean }>({})
 
   const toggleCardExpansion = (cardId: string) => {
     setExpandedCards(prev => {
@@ -49,8 +51,17 @@ export function GalleryContent() {
 
   if (loading) {
     return (
-      <div className="flex justify-center py-12">
-        <div className="text-gray-600">Caricamento galleria...</div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Card key={i} className="overflow-hidden rounded-lg shadow-lg">
+            <Skeleton className="h-60 w-full" />
+            <CardContent className="p-6 space-y-2">
+              <Skeleton className="h-4 w-2/3" />
+              <Skeleton className="h-3 w-1/2" />
+              <Skeleton className="h-3 w-full" />
+            </CardContent>
+          </Card>
+        ))}
       </div>
     )
   }
@@ -72,12 +83,18 @@ export function GalleryContent() {
               className="overflow-hidden rounded-lg shadow-lg hover:shadow-xl transition-shadow duration-300 bg-white group"
             >
               <div className="relative overflow-hidden">
+                {!loadedPreview[image.id] && (
+                  <Skeleton className="absolute inset-0 h-full w-full" />
+                )}
                 <Image
                   src={`/api/image/${image.id}?cb=${Date.now()}`}
                   width={400}
                   height={300}
                   alt={image.alt}
                   className="w-full h-60 object-cover"
+                  onLoadingComplete={() =>
+                    setLoadedPreview(prev => ({ ...prev, [image.id]: true }))
+                  }
                 />
                 <div className="absolute inset-0 bg-black/30 transition-opacity duration-300 group-hover:opacity-0"></div>
               </div>

--- a/components/login-modal.tsx
+++ b/components/login-modal.tsx
@@ -1,6 +1,9 @@
 "use client";
 import React, { useState, useTransition } from "react";
 import { signIn } from "next-auth/react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface LoginModalProps {
   open: boolean;
@@ -37,53 +40,44 @@ export const LoginModal: React.FC<LoginModalProps> = ({ open, onClose }) => {
   }
 
   return (
-    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/30 backdrop-blur-sm transition-opacity duration-200 font-inter">
-      <div className="bg-white-shade p-8 shadow-2xl w-full max-w-sm border border-gray-200 text-gray-800 relative animate-fadeIn">
-        <button
-          className="absolute top-3 right-3 text-gray-400 hover:text-gray-600 transition-colors text-xl font-bold focus:outline-none focus:ring-2 focus:ring-gray-400 rounded-full"
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/30 backdrop-blur-sm font-inter">
+      <Card className="w-full max-w-sm relative p-6">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="absolute top-2 right-2 text-gray-500"
           onClick={onClose}
           aria-label="Chiudi"
           type="button"
         >
           ×
-        </button>
-        <h2 className="text-2xl font-bold mb-6 text-center">Login</h2>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="text"
-            name="username"
-            placeholder="Username"
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-400 bg-white text-gray-800 placeholder-gray-400 transition"
-            autoComplete="username"
-            disabled={isPending}
-          />
-          <input
-            type="password"
-            name="password"
-            placeholder="Password"
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-400 bg-white text-gray-800 placeholder-gray-400 transition"
-            autoComplete="current-password"
-            disabled={isPending}
-          />
-          <button
-            type="submit"
-            className="w-full bg-gray-800 text-white py-2 rounded-lg font-semibold hover:bg-gray-700 transition focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:opacity-60"
-            disabled={isPending}
-          >
-            {isPending ? "Logging in..." : "Login"}
-          </button>
-        </form>
-        {error && <div className="mt-4 text-red-600 text-center">{error}</div>}
-        <style jsx>{`
-          @keyframes fadeIn {
-            from { opacity: 0; transform: scale(0.97); }
-            to { opacity: 1; transform: scale(1); }
-          }
-          .animate-fadeIn {
-            animation: fadeIn 0.2s ease;
-          }
-        `}</style>
-      </div>
+        </Button>
+        <CardHeader>
+          <CardTitle className="text-center">Login</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              type="text"
+              name="username"
+              placeholder="Username"
+              autoComplete="username"
+              disabled={isPending}
+            />
+            <Input
+              type="password"
+              name="password"
+              placeholder="Password"
+              autoComplete="current-password"
+              disabled={isPending}
+            />
+            {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+            <Button type="submit" className="w-full" disabled={isPending}>
+              {isPending ? "Logging in..." : "Login"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
     </div>
   );
-}; 
+};

--- a/components/reels-content.tsx
+++ b/components/reels-content.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react"
 import Image from "next/image"
+import { Skeleton } from "@/components/ui/skeleton"
 import { ChevronUp, ChevronDown, Play, Pause, ChevronUp as ExpandIcon, ChevronDown as CollapseIcon } from "lucide-react"
 
 interface ReelMedia {
@@ -21,6 +22,7 @@ export function ReelsContent() {
   const [isAutoPlay, setIsAutoPlay] = useState(true)
   const [videoError, setVideoError] = useState<string | null>(null)
   const [videoLoading, setVideoLoading] = useState(false)
+  const [mediaLoaded, setMediaLoaded] = useState(false)
   const [isMounted, setIsMounted] = useState(false)
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -151,6 +153,10 @@ export function ReelsContent() {
   const currentMedia = reelsMedia[currentIndex]
   const isDescriptionLong = currentMedia ? currentMedia.description.length > 150 : false
 
+  useEffect(() => {
+    setMediaLoaded(false)
+  }, [currentIndex])
+
   // Don't render until mounted to prevent hydration mismatch
   if (!isMounted) {
     return (
@@ -170,70 +176,81 @@ export function ReelsContent() {
 
   return (
     <div className="space-y-8">
-      {currentMedia ? <>
-      <div 
-        ref={containerRef}
-        className="relative h-[80vh] max-h-[600px] w-full max-w-md mx-auto bg-black rounded-2xl overflow-hidden shadow-2xl"
-      >
-        {/* Current Media Display */}
-        <div className="relative w-full h-full">
-          {currentMedia.medium === "image" ? (
-            <Image
-              src={`/api/image/${currentMedia.id}`}
-              alt={currentMedia.alt}
-              fill
-              className="object-cover"
-              priority
-            />
-          ) : (
-            <>
-              <video
-                ref={(el) => {
-                  videoRefs.current[currentMedia.id] = el
-                }}
-                src={`/api/video/${currentMedia.id}`}
-                className="w-full h-full object-cover"
-                loop
-                muted
-                playsInline
-                controls={false}
-                preload="metadata"
-                onLoadStart={() => setVideoLoading(true)}
-                onLoadedData={() => {
-                  setVideoLoading(false)
-                  const video = videoRefs.current[currentMedia.id]
-                  if (video && isPlaying) {
-                    video.play().catch(console.log)
-                  }
-                }}
-                onError={(e) => {
-                  console.log("Video error:", e)
-                  setVideoLoading(false)
-                  setVideoError("Impossibile caricare il video. Per favore, prova a ricaricare la pagina.")
-                }}
-              >
-                <source src={`/api/video/${currentMedia.id}`} type="video/mp4" />
-                Il tuo browser non supporta il tag video.
-              </video>
-
-              {/* Loading indicator */}
-              {videoLoading && (
-                <div className="absolute inset-0 flex items-center justify-center bg-black/50">
-                  <div className="text-white text-lg">Caricamento video...</div>
-                </div>
+      {currentMedia ? (
+        <>
+          <div
+            ref={containerRef}
+            className="relative h-[80vh] max-h-[600px] w-full max-w-md mx-auto bg-black rounded-2xl overflow-hidden shadow-2xl"
+          >
+            {/* Current Media Display */}
+            <div className="relative w-full h-full">
+              {!mediaLoaded && (
+                <Skeleton className="absolute inset-0 h-full w-full" />
               )}
+              {currentMedia.medium === "image" ? (
+                <Image
+                  src={`/api/image/${currentMedia.id}`}
+                  alt={currentMedia.alt}
+                  fill
+                  className="object-cover"
+                  priority
+                  onLoadingComplete={() => setMediaLoaded(true)}
+                />
+              ) : (
+                <>
+                  <video
+                    ref={el => {
+                      videoRefs.current[currentMedia.id] = el
+                    }}
+                    src={`/api/video/${currentMedia.id}`}
+                    className="w-full h-full object-cover"
+                    loop
+                    muted
+                    playsInline
+                    controls={false}
+                    preload="metadata"
+                    onLoadStart={() => {
+                      setVideoLoading(true)
+                      setMediaLoaded(false)
+                    }}
+                    onLoadedData={() => {
+                      setVideoLoading(false)
+                      setMediaLoaded(true)
+                      const video = videoRefs.current[currentMedia.id]
+                      if (video && isPlaying) {
+                        video.play().catch(console.log)
+                      }
+                    }}
+                    onError={e => {
+                      console.log("Video error:", e)
+                      setVideoLoading(false)
+                      setVideoError(
+                        "Impossibile caricare il video. Per favore, prova a ricaricare la pagina."
+                      )
+                    }}
+                  >
+                    <source src={`/api/video/${currentMedia.id}`} type="video/mp4" />
+                    Il tuo browser non supporta il tag video.
+                  </video>
 
-              {/* Fallback for video errors */}
-              {videoError && (
-                <div className="absolute inset-0 flex items-center justify-center bg-gray-900">
-                  <div className="text-white text-center p-4">
-                    <div className="text-lg mb-2">Video non disponibile</div>
-                    <div className="text-sm opacity-75">{videoError}</div>
-                  </div>
-                </div>
+                  {/* Loading indicator */}
+                  {videoLoading && (
+                    <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+                      <div className="text-white text-lg">Caricamento video...</div>
+                    </div>
+                  )}
+
+                  {/* Fallback for video errors */}
+                  {videoError && (
+                    <div className="absolute inset-0 flex items-center justify-center bg-gray-900">
+                      <div className="text-white text-center p-4">
+                        <div className="text-lg mb-2">Video non disponibile</div>
+                        <div className="text-sm opacity-75">{videoError}</div>
+                      </div>
+                    </div>
+                  )}
+                </>
               )}
-            </>
-          )}
 
           {/* Overlay with media info - now with expandable description */}
           <div className={`absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent p-6 text-white transition-all duration-300 ${
@@ -327,10 +344,13 @@ export function ReelsContent() {
         <p className="text-xs">
           {currentIndex + 1} of {reelsMedia.length}
         </p>
-      </div></>:
-      <div className="flex justify-center py-12">
-        <div className="text-gray-600">Nessun media disponibile.</div>
-      </div>}
+      </div>
+        </>
+      ) : (
+        <div className="flex justify-center py-12">
+          <div className="text-gray-600">Nessun media disponibile.</div>
+        </div>
+      )}
     </div>
   )
 }

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = "text", ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,12 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-gray-200", className)}
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- improve media manager with tag-based visibility controls, image placeholders, and styled file picker
- add skeleton loaders across gallery and profile sections
- restyle login modal using shadcn components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68937f4128dc832da250c367c182fc67