### PR TITLE
Improve media manager and login UI

### DIFF
--- a/components/admin-media-manager.tsx
+++ b/components/admin-media-manager.tsx
@@ -5,6 +5,8 @@ import Image from "next/image"
 import { useSession } from "next-auth/react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { cn } from "@/lib/utils"
 
 interface MediaItem {
   id: string
@@ -23,15 +25,36 @@ interface DraftItem extends MediaItem {
 }
 
 const visibilityOptions = [
-  { value: "gallery", label: "Solo galleria" },
-  { value: "reels", label: "Solo reels" },
-  { value: "both", label: "Entrambi" },
-  { value: "none", label: "Nessuno" }
+  {
+    value: "gallery",
+    label: "Solo galleria",
+    color: "border-green-600 text-green-600",
+    active: "bg-green-600 text-white",
+  },
+  {
+    value: "reels",
+    label: "Solo reels",
+    color: "border-purple-600 text-purple-600",
+    active: "bg-purple-600 text-white",
+  },
+  {
+    value: "both",
+    label: "Entrambi",
+    color: "border-blue-600 text-blue-600",
+    active: "bg-blue-600 text-white",
+  },
+  {
+    value: "none",
+    label: "Nessuno",
+    color: "border-gray-600 text-gray-600",
+    active: "bg-gray-600 text-white",
+  },
 ]
 
 export function AdminMediaManager() {
   const { data: session } = useSession()
   const [media, setMedia] = useState<DraftItem[]>([])
+  const [loading, setLoading] = useState(true)
   const fileInputs = useRef<{ [key: string]: HTMLInputElement | null }>({})
 
   useEffect(() => {
@@ -41,12 +64,14 @@ export function AdminMediaManager() {
   }, [session])
 
   async function fetchAll() {
+    setLoading(true)
     const [imgsRes, vidsRes] = await Promise.all([
       fetch("/api/image?all=1"),
       fetch("/api/video?all=1"),
     ])
     const [imgs, vids] = await Promise.all([imgsRes.json(), vidsRes.json()])
     setMedia([...imgs, ...vids])
+    setLoading(false)
   }
 
   const visibilityValue = (item: MediaItem) => {
@@ -110,73 +135,109 @@ export function AdminMediaManager() {
     <section className="py-20 px-4 bg-gray-100">
       <div className="max-w-6xl mx-auto space-y-8">
         <h2 className="text-3xl font-bold text-center">Gestione Media</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {media.map(item => (
-            <Card key={item.id} className="overflow-hidden">
-              <div className="relative h-48 bg-gray-200">
-                {item.medium === "image" ? (
-                  <Image
-                    src={`/api/image/${item.id}`}
-                    alt={item.alt}
-                    fill
-                    className="object-cover"
-                  />
-                ) : (
-                  <video
-                    src={`/api/video/${item.id}`}
-                    className="w-full h-full object-cover"
-                    controls
-                  />
-                )}
-              </div>
-              <CardContent className="space-y-2 p-4">
-                <input
-                  type="text"
-                  value={item.title}
-                  onChange={e => handleFieldChange(item.id, "title", e.target.value)}
-                  className="w-full border rounded px-2 py-1"
-                />
-                <textarea
-                  value={item.description}
-                  onChange={e => handleFieldChange(item.id, "description", e.target.value)}
-                  className="w-full border rounded px-2 py-1"
-                />
-                <input
-                  type="text"
-                  value={item.year}
-                  onChange={e => handleFieldChange(item.id, "year", e.target.value)}
-                  className="w-full border rounded px-2 py-1"
-                />
-                <input
-                  type="text"
-                  value={item.alt}
-                  onChange={e => handleFieldChange(item.id, "alt", e.target.value)}
-                  className="w-full border rounded px-2 py-1"
-                />
-                <select
-                  value={visibilityValue(item)}
-                  onChange={e => handleVisibilityChange(item.id, item.medium, e.target.value)}
-                  className="w-full border rounded px-2 py-1"
-                >
-                  {visibilityOptions.map(opt => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
-                <input
-                  type="file"
-                  ref={el => (fileInputs.current[item.id] = el)}
-                  onChange={e => handleFileChange(item.id, e.target.files?.[0])}
-                  className="w-full"
-                />
-                <Button onClick={() => saveItem(item)} className="mt-2">
-                  Salva
-                </Button>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {loading
+              ? Array.from({ length: 6 }).map((_, i) => (
+                  <Card key={i} className="overflow-hidden">
+                    <Skeleton className="h-48 w-full" />
+                    <CardContent className="space-y-2 p-4">
+                      <Skeleton className="h-6 w-full" />
+                      <Skeleton className="h-20 w-full" />
+                      <Skeleton className="h-6 w-1/2" />
+                    </CardContent>
+                  </Card>
+                ))
+              : media.map(item => (
+                  <Card key={item.id} className="overflow-hidden">
+                    <div className="relative h-48 bg-gray-200">
+                      {item.medium === "image" ? (
+                        <Image
+                          src={`/api/image/${item.id}`}
+                          alt={item.alt}
+                          fill
+                          className="object-cover"
+                        />
+                      ) : (
+                        <video
+                          src={`/api/video/${item.id}`}
+                          className="w-full h-full object-cover"
+                          controls
+                        />
+                      )}
+                    </div>
+                    <CardContent className="space-y-2 p-4">
+                      <input
+                        type="text"
+                        value={item.title}
+                        onChange={e => handleFieldChange(item.id, "title", e.target.value)}
+                        className="w-full border rounded px-2 py-1"
+                      />
+                      <textarea
+                        value={item.description}
+                        onChange={e => handleFieldChange(item.id, "description", e.target.value)}
+                        className="w-full border rounded px-2 py-1"
+                      />
+                      <input
+                        type="text"
+                        value={item.year}
+                        onChange={e => handleFieldChange(item.id, "year", e.target.value)}
+                        className="w-full border rounded px-2 py-1"
+                      />
+                      <input
+                        type="text"
+                        value={item.alt}
+                        onChange={e => handleFieldChange(item.id, "alt", e.target.value)}
+                        className="w-full border rounded px-2 py-1"
+                      />
+                      <div className="flex flex-wrap gap-2">
+                        {visibilityOptions.map(opt => {
+                          const selected = visibilityValue(item) === opt.value
+                          return (
+                            <Button
+                              key={opt.value}
+                              type="button"
+                              variant="outline"
+                              className={cn(
+                                "text-xs",
+                                selected ? opt.active : opt.color
+                              )}
+                              onClick={() =>
+                                handleVisibilityChange(item.id, item.medium, opt.value)
+                              }
+                            >
+                              {opt.label}
+                            </Button>
+                          )
+                        })}
+                      </div>
+                      <div className="space-y-1">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className="w-full"
+                          onClick={() => fileInputs.current[item.id]?.click()}
+                        >
+                          {item.file ? "File selezionato" : "Seleziona file"}
+                        </Button>
+                        <input
+                          type="file"
+                          ref={el => (fileInputs.current[item.id] = el)}
+                          onChange={e => handleFileChange(item.id, e.target.files?.[0])}
+                          className="hidden"
+                        />
+                        {item.file && (
+                          <div className="text-xs text-gray-600 truncate">
+                            {item.file.name}
+                          </div>
+                        )}
+                      </div>
+                      <Button onClick={() => saveItem(item)} className="mt-2">
+                        Salva
+                      </Button>
+                    </CardContent>
+                  </Card>
+                ))}
+          </div>
       </div>
     </section>
   )

--- a/components/gallery-content.tsx
+++ b/components/gallery-content.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
 import { useEffect, useState, useCallback } from "react"
 import { GalleryImage } from "@/lib/gallery"
 
@@ -49,8 +50,17 @@ export function GalleryContent() {
 
   if (loading) {
     return (
-      <div className="flex justify-center py-12">
-        <div className="text-gray-600">Caricamento galleria...</div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Card key={i} className="overflow-hidden rounded-lg shadow-lg">
+            <Skeleton className="h-60 w-full" />
+            <CardContent className="p-6 space-y-2">
+              <Skeleton className="h-6 w-1/2" />
+              <Skeleton className="h-4 w-1/3" />
+              <Skeleton className="h-4 w-full" />
+            </CardContent>
+          </Card>
+        ))}
       </div>
     )
   }

--- a/components/login-modal.tsx
+++ b/components/login-modal.tsx
@@ -1,89 +1,81 @@
-"use client";
-import React, { useState, useTransition } from "react";
-import { signIn } from "next-auth/react";
+"use client"
+
+import { useState, useTransition } from "react"
+import { signIn } from "next-auth/react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 
 interface LoginModalProps {
-  open: boolean;
-  onClose: () => void;
+  open: boolean
+  onClose: () => void
 }
 
-export const LoginModal: React.FC<LoginModalProps> = ({ open, onClose }) => {
-  const [error, setError] = useState<string | null>(null);
-  const [isPending, startTransition] = useTransition();
+export function LoginModal({ open, onClose }: LoginModalProps) {
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
 
-  if (!open) return null;
+  if (!open) return null
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    setError(null);
-    const formData = new FormData(e.currentTarget);
-    const username = formData.get("username")?.toString() || "";
-    const password = formData.get("password")?.toString() || "";
+    e.preventDefault()
+    setError(null)
+    const formData = new FormData(e.currentTarget)
+    const username = formData.get("username")?.toString() || ""
+    const password = formData.get("password")?.toString() || ""
 
     startTransition(async () => {
       const res = await signIn("credentials", {
         username,
         password,
         redirect: false,
-      });
+      })
       if (res?.error) {
-        setError("Credenziali non valide.");
-        console.log({res}); 
+        setError("Credenziali non valide.")
       } else if (res?.ok) {
-        onClose();
-        // Optionally, refresh the page or session here
+        onClose()
       }
-    });
+    })
   }
 
   return (
-    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/30 backdrop-blur-sm transition-opacity duration-200 font-inter">
-      <div className="bg-white-shade p-8 shadow-2xl w-full max-w-sm border border-gray-200 text-gray-800 relative animate-fadeIn">
-        <button
-          className="absolute top-3 right-3 text-gray-400 hover:text-gray-600 transition-colors text-xl font-bold focus:outline-none focus:ring-2 focus:ring-gray-400 rounded-full"
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+      <Card className="relative w-full max-w-sm">
+        <Button
+          variant="ghost"
+          className="absolute right-2 top-2" 
           onClick={onClose}
-          aria-label="Chiudi"
-          type="button"
         >
           ×
-        </button>
-        <h2 className="text-2xl font-bold mb-6 text-center">Login</h2>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="text"
-            name="username"
-            placeholder="Username"
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-400 bg-white text-gray-800 placeholder-gray-400 transition"
-            autoComplete="username"
-            disabled={isPending}
-          />
-          <input
-            type="password"
-            name="password"
-            placeholder="Password"
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-400 bg-white text-gray-800 placeholder-gray-400 transition"
-            autoComplete="current-password"
-            disabled={isPending}
-          />
-          <button
-            type="submit"
-            className="w-full bg-gray-800 text-white py-2 rounded-lg font-semibold hover:bg-gray-700 transition focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:opacity-60"
-            disabled={isPending}
-          >
-            {isPending ? "Logging in..." : "Login"}
-          </button>
-        </form>
-        {error && <div className="mt-4 text-red-600 text-center">{error}</div>}
-        <style jsx>{`
-          @keyframes fadeIn {
-            from { opacity: 0; transform: scale(0.97); }
-            to { opacity: 1; transform: scale(1); }
-          }
-          .animate-fadeIn {
-            animation: fadeIn 0.2s ease;
-          }
-        `}</style>
-      </div>
+        </Button>
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl font-bold">Login</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              type="text"
+              name="username"
+              placeholder="Username"
+              autoComplete="username"
+              disabled={isPending}
+            />
+            <Input
+              type="password"
+              name="password"
+              placeholder="Password"
+              autoComplete="current-password"
+              disabled={isPending}
+            />
+            {error && (
+              <p className="text-sm text-red-500 text-center">{error}</p>
+            )}
+            <Button type="submit" className="w-full" disabled={isPending}>
+              {isPending ? "Accesso..." : "Accedi"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
     </div>
-  );
-}; 
+  )
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,5 @@
+import { cn } from "@/lib/utils"
+
+export function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("animate-pulse rounded-md bg-gray-200", className)} {...props} />
+}


### PR DESCRIPTION
## Summary
- style media manager with tag-based visibility and button-driven file selection
- add image skeletons for loading states across gallery and admin views
- restyle login modal with shadcn components for consistent spacing and typography

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68937f4128dc832da250c367c182fc67