### PR TITLE
Persist media across gallery and reels

### DIFF
--- a/components/gallery-content.tsx
+++ b/components/gallery-content.tsx
@@ -12,6 +12,7 @@ export function GalleryContent() {
   const [loading, setLoading] = useState(true)
   const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set())
   const [loadedPreview, setLoadedPreview] = useState<{ [key: string]: boolean }>({})
+  const [cacheBuster, setCacheBuster] = useState(Date.now())
 
   const toggleCardExpansion = (cardId: string) => {
     setExpandedCards(prev => {
@@ -35,6 +36,7 @@ export function GalleryContent() {
       const res = await fetch("/api/image")
       const data = await res.json()
       setImages(data)
+      setCacheBuster(Date.now())
     } catch {
       setImages([])
     } finally {
@@ -87,7 +89,7 @@ export function GalleryContent() {
                   <Skeleton className="absolute inset-0 h-full w-full" />
                 )}
                 <Image
-                  src={`/api/image/${image.id}?cb=${Date.now()}`}
+                  src={`/api/image/${image.id}?cb=${cacheBuster}`}
                   width={400}
                   height={300}
                   alt={image.alt}

--- a/components/reels-content.tsx
+++ b/components/reels-content.tsx
@@ -16,10 +16,10 @@ interface ReelMedia {
   duration?: number // in seconds, for videos
 }
 
-export function ReelsContent() {
+export function ReelsContent({ isActive }: { isActive: boolean }) {
   const [currentIndex, setCurrentIndex] = useState(0)
-  const [isPlaying, setIsPlaying] = useState(true)
-  const [isAutoPlay, setIsAutoPlay] = useState(true)
+  const [isPlaying, setIsPlaying] = useState(isActive)
+  const [isAutoPlay, setIsAutoPlay] = useState(isActive)
   const [videoError, setVideoError] = useState<string | null>(null)
   const [videoLoading, setVideoLoading] = useState(false)
   const [mediaLoaded, setMediaLoaded] = useState(false)
@@ -65,6 +65,11 @@ export function ReelsContent() {
     if (text.length <= maxLength) return text
     return text.substring(0, maxLength).trim() + "..."
   }
+
+  useEffect(() => {
+    setIsPlaying(isActive)
+    setIsAutoPlay(isActive)
+  }, [isActive])
 
   useEffect(() => {
     setIsMounted(true)

--- a/components/unified-gallery.tsx
+++ b/components/unified-gallery.tsx
@@ -59,17 +59,14 @@ export function UnifiedGallery() {
 
         {/* Content */}
         <div className="transition-all duration-500 ease-in-out">
-          {viewMode === "gallery" ? (
-            <div>
-              <GalleryContent />
-            </div>
-          ) : (
-            <div>
-              <ReelsContent />
-            </div>
-          )}
+          <div className={viewMode === "gallery" ? "" : "hidden"}>
+            <GalleryContent />
+          </div>
+          <div className={viewMode === "reels" ? "" : "hidden"}>
+            <ReelsContent isActive={viewMode === "reels"} />
+          </div>
         </div>
       </div>
     </section>
   )
-} 
+}


### PR DESCRIPTION
## Summary
- Keep gallery and reel content mounted and hide inactive view to avoid media reloads
- Add active state handling to reels so playback pauses when hidden
- Use a stable cache buster for gallery images to prevent unnecessary reloads

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893d41e0e40832da87da1b6a1e7a243